### PR TITLE
Support Copilot CLI multi-storage recall and provider-based fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,10 @@ session-recall show <session-id> --json
 ```bash
 session-recall health          # 9-dimension health dashboard
 session-recall schema-check    # validate DB schema after Copilot CLI upgrades
+session-recall repos           # discovered repositories/workspaces across providers
 ```
+
+`session-recall` now supports multi-storage discovery for current Copilot CLI layouts, including session-state sources when legacy `session-store.db` is absent.
 
 ## Health Check
 

--- a/src/session_recall/__main__.py
+++ b/src/session_recall/__main__.py
@@ -1,4 +1,5 @@
 """auto-memory CLI — progressive session disclosure for Copilot CLI."""
+
 import argparse
 import sys
 import time
@@ -16,56 +17,131 @@ def _non_negative_int(v):
 
 
 TIER_MAP = {
-    "list": 1, "files": 1, "checkpoints": 1,   # Tier 1 — cheap scan
-    "search": 2,                                  # Tier 2 — focused search
-    "show": 3,                                    # Tier 3 — deep dive
-    "health": 0, "schema-check": 0,              # Tier 0 — meta/ops
-    "calibrate": 0,                               # Tier 0 — meta (Phase 4)
+    "list": 1,
+    "files": 1,
+    "checkpoints": 1,  # Tier 1 — cheap scan
+    "repos": 1,  # Tier 1 — discovery summary
+    "search": 2,  # Tier 2 — focused search
+    "show": 3,  # Tier 3 — deep dive
+    "health": 0,
+    "schema-check": 0,  # Tier 0 — meta/ops
+    "calibrate": 0,  # Tier 0 — meta (Phase 4)
 }
 
 
 def main() -> None:
     telemetry.init(TELEMETRY_PATH)
     t0 = time.monotonic()
-    parser = argparse.ArgumentParser(prog="auto-memory", description="Query Copilot CLI session history")
+    parser = argparse.ArgumentParser(
+        prog="auto-memory",
+        description="Query session history across supported storage providers",
+    )
     sub = parser.add_subparsers(dest="command")
 
     p_list = sub.add_parser("list", help="Recent sessions")
     p_list.add_argument("--repo", default=None)
     p_list.add_argument("--limit", type=int, default=None)
-    p_list.add_argument("--days", type=int, default=None, help="Only include sessions from last N days (default 30)")
+    p_list.add_argument(
+        "--days",
+        type=int,
+        default=None,
+        help="Only include sessions from last N days (default 30)",
+    )
+    p_list.add_argument(
+        "--provider",
+        choices=["all", "cli", "vscode", "jetbrains", "neovim"],
+        default="all",
+    )
     p_list.add_argument("--json", action="store_true")
 
-    p_schema = sub.add_parser("schema-check", help="Validate DB schema")
+    p_schema = sub.add_parser("schema-check", help="Validate storage compatibility")
     p_schema.add_argument("--json", action="store_true")
+    p_schema.add_argument(
+        "--provider",
+        choices=["all", "cli", "vscode", "jetbrains", "neovim"],
+        default="all",
+    )
 
     p_files = sub.add_parser("files", help="Recently touched files")
     p_files.add_argument("--json", action="store_true")
     p_files.add_argument("--repo", default=None)
     p_files.add_argument("--limit", type=int, default=None)
-    p_files.add_argument("--days", type=int, default=None, help="Only include files from last N days")
+    p_files.add_argument(
+        "--days", type=int, default=None, help="Only include files from last N days"
+    )
+    p_files.add_argument(
+        "--provider",
+        choices=["all", "cli", "vscode", "jetbrains", "neovim"],
+        default="all",
+    )
 
     p_cp = sub.add_parser("checkpoints", help="Recent checkpoints")
     p_cp.add_argument("--json", action="store_true")
     p_cp.add_argument("--repo", default=None)
     p_cp.add_argument("--limit", type=int, default=None)
-    p_cp.add_argument("--days", type=int, default=None, help="Only include checkpoints from last N days")
+    p_cp.add_argument(
+        "--days",
+        type=int,
+        default=None,
+        help="Only include checkpoints from last N days",
+    )
+    p_cp.add_argument(
+        "--provider",
+        choices=["all", "cli", "vscode", "jetbrains", "neovim"],
+        default="all",
+    )
+
+    p_repos = sub.add_parser("repos", help="Discovered repositories/workspaces")
+    p_repos.add_argument("--json", action="store_true")
+    p_repos.add_argument("--limit", type=int, default=None)
+    p_repos.add_argument(
+        "--days", type=int, default=None, help="Only include sessions from last N days"
+    )
+    p_repos.add_argument(
+        "--include-local",
+        action="store_true",
+        help="Include local:* workspace attributions",
+    )
+    p_repos.add_argument(
+        "--provider",
+        choices=["all", "cli", "vscode", "jetbrains", "neovim"],
+        default="all",
+    )
 
     p_show = sub.add_parser("show", help="Show session details")
     p_show.add_argument("session_id")
     p_show.add_argument("--json", action="store_true")
     p_show.add_argument("--turns", type=_non_negative_int, default=None)
     p_show.add_argument("--full", action="store_true")
+    p_show.add_argument(
+        "--provider",
+        choices=["all", "cli", "vscode", "jetbrains", "neovim"],
+        default="all",
+    )
 
     p_search = sub.add_parser("search", help="Full-text search")
     p_search.add_argument("query")
     p_search.add_argument("--json", action="store_true")
     p_search.add_argument("--repo", default=None)
     p_search.add_argument("--limit", type=int, default=None)
-    p_search.add_argument("--days", type=int, default=None, help="Only include sessions from last N days")
+    p_search.add_argument(
+        "--days", type=int, default=None, help="Only include sessions from last N days"
+    )
+    p_search.add_argument(
+        "--provider",
+        choices=["all", "cli", "vscode", "jetbrains", "neovim"],
+        default="all",
+    )
 
-    p_health = sub.add_parser("health", help="Health check (9 dimensions)")
+    p_health = sub.add_parser(
+        "health", help="Health check (SQLite core or provider fallback)"
+    )
     p_health.add_argument("--json", action="store_true")
+    p_health.add_argument(
+        "--provider",
+        choices=["all", "cli", "vscode", "jetbrains", "neovim"],
+        default="all",
+    )
 
     args = parser.parse_args()
     if not args.command:
@@ -75,27 +151,40 @@ def main() -> None:
     exit_code = 1
     if args.command == "list":
         from .commands.list_sessions import run
+
         exit_code = run(args)
     elif args.command == "schema-check":
         from .commands.schema_check_cmd import run
+
         exit_code = run(args)
     elif args.command == "files":
         from .commands.files import run
+
         exit_code = run(args)
     elif args.command == "checkpoints":
         from .commands.checkpoints import run
+
+        exit_code = run(args)
+    elif args.command == "repos":
+        from .commands.repos import run
+
         exit_code = run(args)
     elif args.command == "show":
         from .commands.show_session import run
+
         exit_code = run(args)
     elif args.command == "search":
         from .commands.search import run
+
         exit_code = run(args)
     elif args.command == "health":
         from .commands.health import run
+
         exit_code = run(args)
     else:
-        print(f"'{args.command}' not yet implemented. Coming in Phase 2.", file=sys.stderr)
+        print(
+            f"'{args.command}' not yet implemented. Coming in Phase 2.", file=sys.stderr
+        )
 
     duration_ms = int((time.monotonic() - t0) * 1000)
     tier = TIER_MAP.get(args.command)  # None if command unknown
@@ -107,9 +196,15 @@ def main() -> None:
     elif args.command == "show":
         sid = getattr(args, "session_id", "") or ""
         sid_prefix = sid[:8] if sid else None
-    telemetry.record(cmd=args.command, duration_ms=duration_ms, exit_code=exit_code,
-                     tier=tier, query_hash=qhash, session_id_prefix=sid_prefix,
-                     window_tier=wtier)
+    telemetry.record(
+        cmd=args.command,
+        duration_ms=duration_ms,
+        exit_code=exit_code,
+        tier=tier,
+        query_hash=qhash,
+        session_id_prefix=sid_prefix,
+        window_tier=wtier,
+    )
     sys.exit(exit_code)
 
 

--- a/src/session_recall/commands/checkpoints.py
+++ b/src/session_recall/commands/checkpoints.py
@@ -1,42 +1,40 @@
 """List recent checkpoints with session context."""
+
 import sys
-from ..db.connect import connect_ro
-from ..db.schema_check import schema_check
 from ..config import DB_PATH
+from ..providers.discovery import get_active_providers
 from ..util.detect_repo import detect_repo
 from ..util.format_output import output
 
-_BASE = """SELECT c.checkpoint_number, c.title, c.overview, c.created_at,
-           c.session_id, s.summary as session_summary FROM checkpoints c
-           JOIN sessions s ON s.id = c.session_id"""
-
 
 def run(args) -> int:
-    conn = connect_ro(DB_PATH)
-    problems = schema_check(conn)
-    if problems:
-        for p in problems:
-            print(f"   - {p}", file=sys.stderr)
-        conn.close()
+    try:
+        providers = get_active_providers(
+            getattr(args, "provider", "cli"), db_path=DB_PATH
+        )
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
         return 2
-    repo = getattr(args, 'repo', None) or detect_repo()
-    limit = getattr(args, 'limit', None) or 5
-    days = getattr(args, 'days', None)
-    date_filter = " AND c.created_at >= datetime('now', ?)" if days else ""
-    date_param = (f"-{days} days",) if days else ()
-    if repo and repo != "all":
-        sql = _BASE + f" WHERE s.repository = ?{date_filter} ORDER BY c.created_at DESC LIMIT ?"
-        rows = conn.execute(sql, (repo, *date_param, limit)).fetchall()
-    else:
-        where = f" WHERE 1=1{date_filter}" if days else ""
-        sql = _BASE + where + " ORDER BY c.created_at DESC LIMIT ?"
-        rows = conn.execute(sql, (*date_param, limit)).fetchall()
-    checkpoints = [{
-        "checkpoint_number": r["checkpoint_number"], "title": r["title"],
-        "overview": (r["overview"] or "")[:300], "date": (r["created_at"] or "")[:10],
-        "session_id": r["session_id"][:8], "session_summary": r["session_summary"],
-    } for r in rows]
-    output({"repo": repo or "all", "count": len(checkpoints), "checkpoints": checkpoints},
-           json_mode=getattr(args, 'json', False))
-    conn.close()
+
+    cli_providers = [p for p in providers if p.provider_id == "cli"]
+    if cli_providers:
+        problems = cli_providers[0].schema_problems()
+        if problems:
+            for p in problems:
+                print(f"   - {p}", file=sys.stderr)
+            return 2
+
+    repo = getattr(args, "repo", None) or detect_repo()
+    limit = getattr(args, "limit", None) or 5
+    days = getattr(args, "days", None)
+    checkpoints = []
+    for provider in providers:
+        checkpoints.extend(provider.list_checkpoints(repo=repo, limit=limit, days=days))
+    checkpoints = sorted(checkpoints, key=lambda c: c.get("date") or "", reverse=True)[
+        :limit
+    ]
+    output(
+        {"repo": repo or "all", "count": len(checkpoints), "checkpoints": checkpoints},
+        json_mode=getattr(args, "json", False),
+    )
     return 0

--- a/src/session_recall/commands/files.py
+++ b/src/session_recall/commands/files.py
@@ -1,42 +1,39 @@
 """List recently touched files with session attribution."""
+
 import sys
-from ..db.connect import connect_ro
-from ..db.schema_check import schema_check
 from ..config import DB_PATH
+from ..providers.discovery import get_active_providers
 from ..util.detect_repo import detect_repo
 from ..util.format_output import output
 
-_BASE = """SELECT sf.file_path, sf.tool_name, sf.first_seen_at,
-           sf.session_id, s.summary FROM session_files sf
-           JOIN sessions s ON s.id = sf.session_id"""
-
 
 def run(args) -> int:
-    conn = connect_ro(DB_PATH)
-    problems = schema_check(conn)
-    if problems:
-        for p in problems:
-            print(f"   - {p}", file=sys.stderr)
-        conn.close()
+    try:
+        providers = get_active_providers(
+            getattr(args, "provider", "cli"), db_path=DB_PATH
+        )
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
         return 2
-    repo = getattr(args, 'repo', None) or detect_repo()
-    limit = getattr(args, 'limit', None) or 10
-    days = getattr(args, 'days', None)
-    date_filter = " AND sf.first_seen_at >= datetime('now', ?)" if days else ""
-    date_param = (f"-{days} days",) if days else ()
-    if repo and repo != "all":
-        sql = _BASE + f" WHERE s.repository = ?{date_filter} ORDER BY sf.first_seen_at DESC LIMIT ?"
-        rows = conn.execute(sql, (repo, *date_param, limit)).fetchall()
-    else:
-        where = f" WHERE 1=1{date_filter}" if days else ""
-        sql = _BASE + where + " ORDER BY sf.first_seen_at DESC LIMIT ?"
-        rows = conn.execute(sql, (*date_param, limit)).fetchall()
-    files = [{
-        "file_path": r["file_path"], "tool_name": r["tool_name"],
-        "date": (r["first_seen_at"] or "")[:10],
-        "session_id": r["session_id"][:8], "session_summary": r["summary"],
-    } for r in rows]
-    output({"repo": repo or "all", "count": len(files), "files": files},
-           json_mode=getattr(args, 'json', False))
-    conn.close()
+
+    cli_providers = [p for p in providers if p.provider_id == "cli"]
+    if cli_providers:
+        problems = cli_providers[0].schema_problems()
+        if problems:
+            for p in problems:
+                print(f"   - {p}", file=sys.stderr)
+            return 2
+
+    repo = getattr(args, "repo", None) or detect_repo()
+    limit = getattr(args, "limit", None) or 10
+    days = getattr(args, "days", None)
+    files = []
+    for provider in providers:
+        files.extend(provider.recent_files(repo=repo, limit=limit, days=days))
+
+    files = sorted(files, key=lambda f: f.get("date") or "", reverse=True)[:limit]
+    output(
+        {"repo": repo or "all", "count": len(files), "files": files},
+        json_mode=getattr(args, "json", False),
+    )
     return 0

--- a/src/session_recall/commands/health.py
+++ b/src/session_recall/commands/health.py
@@ -109,7 +109,7 @@ def run(args) -> int:
         print("-" * 70)
         print(f"    {'Overall':<22s}        {score:5.1f}")
         if hints:
-            print(f"\n💡 Hints:")
+            print("\n💡 Hints:")
             for h in hints[:3]:
                 print(f"   • {h}")
         print()

--- a/src/session_recall/commands/health.py
+++ b/src/session_recall/commands/health.py
@@ -1,33 +1,111 @@
 """Health check orchestrator — run all 9 dimensions and report."""
+
 import sys
+from pathlib import Path
 from ..health.scoring import overall_score
-from ..health import (dim_freshness, dim_schema, dim_latency, dim_corpus,
-                      dim_summary_coverage, dim_repo_coverage, dim_concurrency,
-                      dim_e2e, dim_disclosure)
+from ..health import (
+    dim_freshness,
+    dim_schema,
+    dim_latency,
+    dim_corpus,
+    dim_summary_coverage,
+    dim_repo_coverage,
+    dim_concurrency,
+    dim_e2e,
+    dim_disclosure,
+)
+from ..config import DB_PATH
+from ..providers.discovery import get_active_providers
 from ..util.format_output import fmt_json
 
-DIMS = [dim_freshness, dim_schema, dim_latency, dim_corpus,
-        dim_summary_coverage, dim_repo_coverage, dim_concurrency, dim_e2e,
-        dim_disclosure]
+DIMS = [
+    dim_freshness,
+    dim_schema,
+    dim_latency,
+    dim_corpus,
+    dim_summary_coverage,
+    dim_repo_coverage,
+    dim_concurrency,
+    dim_e2e,
+    dim_disclosure,
+]
 
 ZONE_ICON = {"GREEN": "🟢", "AMBER": "🟡", "RED": "🔴"}
 ZONE_ICON["CALIBRATING"] = "⚪"
 
 
+def _provider_dim(provider) -> dict:
+    """Compute a lightweight health dimension for a provider backend."""
+    sessions = provider.list_sessions(repo="all", limit=20, days=30)
+    count = len(sessions)
+    if count > 0:
+        return {
+            "name": f"Provider:{provider.provider_id}",
+            "zone": "GREEN",
+            "score": 10.0,
+            "detail": f"{count} recent sessions detected",
+            "hint": "",
+        }
+    return {
+        "name": f"Provider:{provider.provider_id}",
+        "zone": "AMBER",
+        "score": 5.0,
+        "detail": "Provider available, but no recent sessions found",
+        "hint": f"Open/use {provider.provider_name} and retry health.",
+    }
+
+
 def run(args) -> int:
-    results = [d.check() for d in DIMS]
+    provider_arg = getattr(args, "provider", "all")
+    try:
+        providers = get_active_providers(provider_arg, DB_PATH)
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    has_sqlite = Path(DB_PATH).exists() and any(
+        p.provider_id == "cli" for p in providers
+    )
+    results = [d.check() for d in DIMS] if has_sqlite else []
+
+    if not has_sqlite:
+        results.append(
+            {
+                "name": "SQLite Health Core",
+                "zone": "CALIBRATING",
+                "score": None,
+                "detail": "session-store.db unavailable; running provider compatibility health",
+                "hint": "Set SESSION_RECALL_DB if SQLite storage exists on this machine.",
+            }
+        )
+
+    for provider in providers:
+        results.append(_provider_dim(provider))
+
     score = overall_score(results)
     hints = [r["hint"] for r in results if r["zone"] != "GREEN" and r.get("hint")]
 
     if getattr(args, "json", False):
-        print(fmt_json({"overall_score": score, "dims": results, "top_hints": hints[:3]}))
+        print(
+            fmt_json(
+                {
+                    "overall_score": score,
+                    "dims": results,
+                    "providers": [p.provider_id for p in providers],
+                    "storage_mode": "sqlite" if has_sqlite else "provider-fallback",
+                    "top_hints": hints[:3],
+                }
+            )
+        )
     else:
         print(f"\n{'Dim':<3s} {'Name':<22s} {'Zone':<8s} {'Score':>5s}  Detail")
         print("-" * 70)
         for i, r in enumerate(results, 1):
             icon = ZONE_ICON.get(r["zone"], "?")
             score_str = f"{r['score']:5.1f}" if r.get("score") is not None else "  -  "
-            print(f" {i:<2d} {r['name']:<22s} {icon} {r['zone']:<5s} {score_str}  {r['detail']}")
+            print(
+                f" {i:<2d} {r['name']:<22s} {icon} {r['zone']:<5s} {score_str}  {r['detail']}"
+            )
         print("-" * 70)
         print(f"    {'Overall':<22s}        {score:5.1f}")
         if hints:

--- a/src/session_recall/commands/list_sessions.py
+++ b/src/session_recall/commands/list_sessions.py
@@ -1,81 +1,101 @@
 """List recent sessions for the current (or specified) repository."""
-import os
+
 import sys
 
 from ..config import DB_PATH
-from ..db.connect import connect_ro
-from ..db.schema_check import schema_check
+from ..providers.discovery import get_active_providers
 from ..util.detect_repo import detect_repo
 from ..util.format_output import output
-
-_QUERY_REPO = """
-    SELECT s.id, s.repository, s.branch, s.summary, s.created_at, s.updated_at,
-           (SELECT COUNT(*) FROM turns t WHERE t.session_id = s.id) as turns_count,
-           (SELECT COUNT(*) FROM session_files f WHERE f.session_id = s.id) as files_count
-    FROM sessions s WHERE s.repository = ? AND s.created_at >= datetime('now', ?)
-    ORDER BY s.created_at DESC LIMIT ?"""
-
-_QUERY_ALL = """
-    SELECT s.id, s.repository, s.branch, s.summary, s.created_at, s.updated_at,
-           (SELECT COUNT(*) FROM turns t WHERE t.session_id = s.id) as turns_count,
-           (SELECT COUNT(*) FROM session_files f WHERE f.session_id = s.id) as files_count
-    FROM sessions s WHERE s.created_at >= datetime('now', ?)
-    ORDER BY s.created_at DESC LIMIT ?"""
 
 
 def run(args) -> int:
     """Execute the list subcommand. Returns exit code."""
     repo = args.repo or detect_repo()
-    conn = connect_ro(DB_PATH)
-    problems = schema_check(conn)
-    if problems:
-        print("❌ Schema drift:", file=sys.stderr)
-        for p in problems:
-            print(f"   - {p}", file=sys.stderr)
-        conn.close()
+    limit = args.limit or 50
+    days = args.days or 30
+    try:
+        providers = get_active_providers(
+            getattr(args, "provider", "cli"), db_path=DB_PATH
+        )
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
         return 2
-    limit = args.limit or 10
-    days_arg = f"-{args.days or 30} days"
-    if repo and repo != "all":
-        rows = conn.execute(_QUERY_REPO, (repo, days_arg, limit)).fetchall()
-    else:
-        rows = conn.execute(_QUERY_ALL, (days_arg, limit)).fetchall()
-    sessions = [
-        {
-            "id_short": r["id"][:8], "id_full": r["id"],
-            "repository": r["repository"], "branch": r["branch"],
-            "summary": r["summary"],
-            "date": r["created_at"][:10] if r["created_at"] else None,
-            "created_at": r["created_at"],
-            "turns_count": r["turns_count"], "files_count": r["files_count"],
+
+    cli_providers = [p for p in providers if p.provider_id == "cli"]
+    if cli_providers:
+        problems = cli_providers[0].schema_problems()
+        if problems:
+            print("❌ Schema drift:", file=sys.stderr)
+            for p in problems:
+                print(f"   - {p}", file=sys.stderr)
+            return 2
+
+    sessions = []
+    recent_files = []
+    for provider in providers:
+        sessions.extend(provider.list_sessions(repo=repo, limit=limit, days=days))
+        recent_files.extend(provider.recent_files(repo=repo, limit=10, days=days))
+
+    scope = repo or "all"
+    scope_fallback_used = False
+    selected_provider = getattr(args, "provider", "all")
+    has_non_cli_provider = any(
+        getattr(p, "provider_id", "") != "cli" for p in providers
+    )
+    allow_cli_topup = selected_provider == "cli" or (
+        selected_provider == "all" and has_non_cli_provider
+    )
+    if repo and repo != "all" and len(sessions) < limit and allow_cli_topup:
+        # Some providers cannot always infer repo ownership from raw event logs.
+        # Top up from all repos so recall remains useful instead of looking sparse.
+        existing_keys = {
+            (str(s.get("provider") or ""), str(s.get("id_full") or s.get("id") or ""))
+            for s in sessions
         }
-        for r in rows
-    ]
-    recent_files = _recent_files(conn, repo, limit=10)
-    data = {"repo": repo or "all", "count": len(sessions),
-            "sessions": sessions, "recent_files": recent_files}
+        filled = len(sessions)
+        added_count = 0
+        for provider in providers:
+            if getattr(provider, "provider_id", "") != "cli":
+                continue
+            if filled >= limit:
+                break
+            candidates = provider.list_sessions(repo="all", limit=limit, days=days)
+            for candidate in candidates:
+                key = (
+                    str(candidate.get("provider") or ""),
+                    str(candidate.get("id_full") or candidate.get("id") or ""),
+                )
+                if key in existing_keys:
+                    continue
+                sessions.append(candidate)
+                existing_keys.add(key)
+                filled += 1
+                added_count += 1
+                if filled >= limit:
+                    break
+        if added_count > 0:
+            scope = "all"
+            scope_fallback_used = True
+
+    # Keep scope metadata accurate: if any all-scope top-up happened, scope must be all.
+    if scope_fallback_used:
+        scope = "all"
+
+    sessions = sorted(
+        sessions,
+        key=lambda s: s.get("created_at") or "",
+        reverse=True,
+    )[:limit]
+    recent_files = sorted(
+        recent_files, key=lambda f: f.get("date") or "", reverse=True
+    )[:10]
+
+    data = {
+        "repo": scope,
+        "count": len(sessions),
+        "sessions": sessions,
+        "recent_files": recent_files,
+        "scope_fallback_used": scope_fallback_used,
+    }
     output(data, json_mode=args.json)
-    conn.close()
     return 0
-
-
-_FILES_SQL = """SELECT sf.file_path, sf.tool_name, sf.first_seen_at, sf.session_id
-FROM session_files sf JOIN sessions s ON s.id = sf.session_id
-WHERE sf.file_path LIKE '%%.md'{repo_filter}
-ORDER BY sf.first_seen_at DESC LIMIT ?"""
-
-
-def _recent_files(conn, repo, limit=10):
-    if repo and repo != "all":
-        sql = _FILES_SQL.format(repo_filter=" AND s.repository = ?")
-        rows = conn.execute(sql, (repo, limit)).fetchall()
-    else:
-        sql = _FILES_SQL.format(repo_filter="")
-        rows = conn.execute(sql, (limit,)).fetchall()
-    cwd = os.getcwd()
-    return [{"file_path": os.path.relpath(r["file_path"], cwd)
-                          if r["file_path"].startswith(cwd) else r["file_path"],
-             "full_path": r["file_path"],
-             "tool_name": r["tool_name"],
-             "date": (r["first_seen_at"] or "")[:10],
-             "session_id": r["session_id"][:8]} for r in rows]

--- a/src/session_recall/commands/repos.py
+++ b/src/session_recall/commands/repos.py
@@ -1,0 +1,88 @@
+"""Summarize discovered repositories/workspaces from session history."""
+
+from __future__ import annotations
+
+import sys
+
+from ..config import DB_PATH
+from ..providers.discovery import get_active_providers
+from ..util.format_output import output
+
+
+def _print_human(rows: list[dict]) -> None:
+    if not rows:
+        print("No repositories discovered.")
+        return
+    print(
+        f"{'Repository/Workspace':42s}  {'Sessions':>8s}  {'Last Seen':10s}  Providers"
+    )
+    print("-" * 90)
+    for row in rows:
+        name = str(row.get("repository") or "unknown")[:42]
+        count = str(row.get("session_count") or 0)
+        last = str(row.get("last_seen") or "")[:10]
+        providers = ",".join(row.get("providers") or [])
+        print(f"{name:42s}  {count:>8s}  {last:10s}  {providers}")
+
+
+def run(args) -> int:
+    limit = getattr(args, "limit", None) or 500
+    days = getattr(args, "days", None) or 30
+    include_local = bool(getattr(args, "include_local", False))
+
+    try:
+        providers = get_active_providers(
+            getattr(args, "provider", "all"), db_path=DB_PATH
+        )
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    sessions: list[dict] = []
+    for provider in providers:
+        sessions.extend(provider.list_sessions(repo="all", limit=limit, days=days))
+
+    buckets: dict[str, dict] = {}
+    for sess in sessions:
+        repo = str(sess.get("repository") or "unknown")
+        created = str(sess.get("created_at") or "")
+        provider = str(sess.get("provider") or "unknown")
+
+        row = buckets.get(repo)
+        if row is None:
+            row = {
+                "repository": repo,
+                "session_count": 0,
+                "last_seen": created,
+                "providers": set(),
+            }
+            buckets[repo] = row
+        row["session_count"] += 1
+        if created > str(row["last_seen"] or ""):
+            row["last_seen"] = created
+        row["providers"].add(provider)
+
+    rows = list(buckets.values())
+    if not include_local:
+        rows = [
+            r for r in rows if not str(r.get("repository") or "").startswith("local:")
+        ]
+    rows.sort(
+        key=lambda r: (-int(r["session_count"]), str(r["last_seen"] or "")),
+        reverse=False,
+    )
+    for row in rows:
+        row["providers"] = sorted(row["providers"])
+
+    payload = {
+        "count": len(rows),
+        "days": days,
+        "include_local": include_local,
+        "repositories": rows,
+    }
+
+    if getattr(args, "json", False):
+        output(payload, json_mode=True)
+    else:
+        _print_human(rows)
+    return 0

--- a/src/session_recall/commands/schema_check_cmd.py
+++ b/src/session_recall/commands/schema_check_cmd.py
@@ -1,23 +1,59 @@
 """Schema-check subcommand — validates session-store.db structure."""
+
 import sys
 from ..config import DB_PATH
-from ..db.connect import connect_ro
-from ..db.schema_check import schema_check
+from ..providers.discovery import get_active_providers
 from ..util.format_output import fmt_json
 
+
 def run(args) -> int:
-    """Execute schema-check. Returns 0 if OK, 2 if drift."""
-    conn = connect_ro(DB_PATH)
-    problems = schema_check(conn)
-    conn.close()
+    """Execute schema-check across available providers."""
+    provider_arg = getattr(args, "provider", "all")
     json_mode = getattr(args, "json", False)
-    if problems:
+    try:
+        providers = get_active_providers(provider_arg, DB_PATH)
+    except ValueError as e:
         if json_mode:
-            print(fmt_json({"ok": False, "problems": problems}))
+            print(fmt_json({"ok": False, "problems": [str(e)], "providers": []}))
         else:
-            print("❌ Schema drift. Copilot CLI may have been upgraded.", file=sys.stderr)
-            for p in problems:
-                print(f"   - {p}", file=sys.stderr)
+            print(f"error: {e}", file=sys.stderr)
         return 2
-    print(fmt_json({"ok": True, "problems": []}) if json_mode else "✅ Schema OK")
-    return 0
+
+    provider_rows = []
+    all_problems = []
+    for provider in providers:
+        problems = provider.schema_problems()
+        mode = "sqlite" if provider.provider_id == "cli" else "file"
+        row = {
+            "provider": provider.provider_id,
+            "ok": not problems,
+            "mode": mode,
+            "problems": problems,
+        }
+        if provider.provider_id == "cli" and not problems:
+            # In session-state fallback mode, schema checks are not applicable.
+            row["mode"] = "session-state-or-sqlite"
+            row["detail"] = (
+                "Schema checks apply to SQLite when present; fallback event storage has no SQL schema."
+            )
+        provider_rows.append(row)
+        for p in problems:
+            all_problems.append(f"{provider.provider_id}: {p}")
+
+    ok = len(all_problems) == 0
+    if json_mode:
+        print(
+            fmt_json({"ok": ok, "problems": all_problems, "providers": provider_rows})
+        )
+        return 0 if ok else 2
+
+    if ok:
+        print("✅ Schema checks passed for active provider(s)")
+        for row in provider_rows:
+            print(f"   - {row['provider']}: OK ({row.get('mode', 'n/a')})")
+        return 0
+
+    print("❌ Schema/check compatibility issues detected.", file=sys.stderr)
+    for problem in all_problems:
+        print(f"   - {problem}", file=sys.stderr)
+    return 2

--- a/src/session_recall/commands/search.py
+++ b/src/session_recall/commands/search.py
@@ -1,22 +1,12 @@
 """Full-text search across session turns and summaries."""
+
 import re
 import sys
-from ..db.connect import connect_ro
-from ..db.schema_check import schema_check
+
 from ..config import DB_PATH
+from ..providers.discovery import get_active_providers
 from ..util.detect_repo import detect_repo
 from ..util.format_output import output
-
-_SQL = """SELECT si.content, si.session_id, si.source_type,
-       s.summary, s.created_at, s.repository
-FROM search_index si JOIN sessions s ON s.id = si.session_id
-WHERE search_index MATCH ?{repo_filter} ORDER BY rank LIMIT ?"""
-
-_FILE_SQL = """SELECT sf.file_path, sf.session_id, sf.tool_name, sf.first_seen_at,
-       s.summary, s.created_at, s.repository
-FROM session_files sf JOIN sessions s ON s.id = sf.session_id
-WHERE sf.file_path LIKE ?{repo_filter}
-ORDER BY sf.first_seen_at DESC LIMIT ?"""
 
 # FTS5 special chars that cause syntax errors when unquoted
 _FTS5_SPECIAL = re.compile(r'[.\-(){}[\]^~*:"+/\\@#$%&!?<>=|]')
@@ -35,69 +25,66 @@ def sanitize_fts5_query(raw: str) -> str | None:
     tokens = stripped.split()
     safe_tokens = []
     for tok in tokens:
-        # Escape internal double quotes
         escaped = tok.replace('"', '""')
         if _FTS5_SPECIAL.search(tok):
-            # Quote the whole token to treat special chars as literals
             safe_tokens.append(f'"{escaped}"')
         else:
-            # Bare token with prefix wildcard for partial matching
-            safe_tokens.append(f'{escaped}*')
+            safe_tokens.append(f"{escaped}*")
     return " ".join(safe_tokens)
 
 
 def run(args) -> int:
-    conn = connect_ro(DB_PATH)
-    problems = schema_check(conn)
-    if problems:
-        for p in problems:
-            print(f"   - {p}", file=sys.stderr)
-        conn.close()
-        return 2
     raw_query = args.query
-    repo = getattr(args, 'repo', None) or detect_repo()
-    limit = getattr(args, 'limit', None) or 5
-    days = getattr(args, 'days', None)
-    has_repo = repo and repo != "all"
-    date_clause = " AND s.created_at >= datetime('now', ?)" if days else ""
-    date_param = (f"-{days} days",) if days else ()
+    repo = getattr(args, "repo", None) or detect_repo()
+    limit = getattr(args, "limit", None) or 5
+    days = getattr(args, "days", None)
+
+    try:
+        providers = get_active_providers(
+            getattr(args, "provider", "cli"), db_path=DB_PATH
+        )
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    cli_providers = [p for p in providers if p.provider_id == "cli"]
+    if cli_providers:
+        problems = cli_providers[0].schema_problems()
+        if problems:
+            for p in problems:
+                print(f"   - {p}", file=sys.stderr)
+            return 2
 
     fts_query = sanitize_fts5_query(raw_query)
     if fts_query is None:
-        data = {"query": raw_query, "repo": repo or "all", "count": 0, "results": [],
-                "warning": "Empty query — nothing to search"}
-        output(data, json_mode=getattr(args, 'json', False))
-        conn.close()
+        data = {
+            "query": raw_query,
+            "repo": repo or "all",
+            "count": 0,
+            "results": [],
+            "warning": "Empty query — nothing to search",
+        }
+        output(data, json_mode=getattr(args, "json", False))
         return 0
 
-    if has_repo:
-        sql = _SQL.format(repo_filter=" AND s.repository = ?" + date_clause)
-        rows = conn.execute(sql, (fts_query, repo, *date_param, limit)).fetchall()
-    else:
-        sql = _SQL.format(repo_filter=date_clause)
-        rows = conn.execute(sql, (fts_query, *date_param, limit)).fetchall()
-    results = [{"session_id": r["session_id"][:8], "session_id_full": r["session_id"],
-                "source_type": r["source_type"], "summary": r["summary"],
-                "date": (r["created_at"] or "")[:10], "excerpt": (r["content"] or "")[:200]}
-               for r in rows]
-    seen = {(r["session_id_full"], r["source_type"]) for r in results}
-    like_pat = f"%{raw_query}%"
-    if has_repo:
-        fsql = _FILE_SQL.format(repo_filter=" AND s.repository = ?" + date_clause)
-        frows = conn.execute(fsql, (like_pat, repo, *date_param, limit)).fetchall()
-    else:
-        fsql = _FILE_SQL.format(repo_filter=date_clause)
-        frows = conn.execute(fsql, (like_pat, *date_param, limit)).fetchall()
-    for r in frows:
-        if (r["session_id"], "file") in seen:
-            continue
-        seen.add((r["session_id"], "file"))
-        results.append({"session_id": r["session_id"][:8], "session_id_full": r["session_id"],
-                         "source_type": "file", "summary": r["summary"],
-                         "date": (r["created_at"] or "")[:10],
-                         "excerpt": f"{r['file_path']} ({r['tool_name']})"})
-    results = results[:limit]
-    data = {"query": raw_query, "repo": repo or "all", "count": len(results), "results": results}
-    output(data, json_mode=getattr(args, 'json', False))
-    conn.close()
+    results = []
+    for provider in providers:
+        results.extend(provider.search(raw_query, repo=repo, limit=limit, days=days))
+
+    scope = repo or "all"
+    if not results and repo and repo != "all":
+        for provider in providers:
+            results.extend(
+                provider.search(raw_query, repo="all", limit=limit, days=days)
+            )
+        scope = "all"
+
+    results = sorted(results, key=lambda r: r.get("date") or "", reverse=True)[:limit]
+    data = {
+        "query": raw_query,
+        "repo": scope,
+        "count": len(results),
+        "results": results,
+    }
+    output(data, json_mode=getattr(args, "json", False))
     return 0

--- a/src/session_recall/commands/show_session.py
+++ b/src/session_recall/commands/show_session.py
@@ -1,73 +1,50 @@
 """Show detailed info for a single session."""
+
 import re
 import sys
-from ..db.connect import connect_ro
-from ..db.schema_check import schema_check
 from ..config import DB_PATH
+from ..providers.discovery import get_active_providers
 from ..util.format_output import output
 
-_SID_RE = re.compile(r'^[0-9a-fA-F-]{4,}$')
+_SID_RE = re.compile(r"^[0-9a-fA-F-]{4,}$")
 
 
 def run(args) -> int:
-    conn = connect_ro(DB_PATH)
-    problems = schema_check(conn)
-    if problems:
-        for p in problems:
-            print(f"   - {p}", file=sys.stderr)
-        conn.close()
+    try:
+        providers = get_active_providers(
+            getattr(args, "provider", "cli"), db_path=DB_PATH
+        )
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
         return 2
+
+    cli_providers = [p for p in providers if p.provider_id == "cli"]
+    if cli_providers:
+        problems = cli_providers[0].schema_problems()
+        if problems:
+            for p in problems:
+                print(f"   - {p}", file=sys.stderr)
+            return 2
+
     sid = args.session_id.strip()
-    if not _SID_RE.match(sid) or not sid.replace('-', ''):
+    selected_provider = getattr(args, "provider", "cli")
+    cli_like_id = selected_provider == "cli" or ":" not in sid
+    if cli_like_id and (not _SID_RE.match(sid) or not sid.replace("-", "")):
         print(
             f"error: invalid session id '{args.session_id}' "
             f"(expected hex, 4+ chars)",
             file=sys.stderr,
         )
-        conn.close()
         return 2
     sid = sid.lower()
-    row = conn.execute(
-        "SELECT * FROM sessions WHERE id = ? OR id LIKE ?", (sid, f"{sid}%"),
-    ).fetchone()
-    if not row:
-        print(f"No session found matching '{sid}'", file=sys.stderr)
-        conn.close()
-        return 1
-    full_id = row["id"]
-    if getattr(args, 'turns', None) is not None:
-        turns_rows = conn.execute(
-            "SELECT turn_index, user_message, assistant_response, timestamp "
-            "FROM turns WHERE session_id = ? ORDER BY turn_index LIMIT ?",
-            (full_id, args.turns),
-        ).fetchall()
-    else:
-        turns_rows = conn.execute(
-            "SELECT turn_index, user_message, assistant_response, timestamp "
-            "FROM turns WHERE session_id = ? ORDER BY turn_index",
-            (full_id,),
-        ).fetchall()
-    mx = 99999 if getattr(args, 'full', False) else 500
-    turns = [{"idx": t["turn_index"], "user": (t["user_message"] or "")[:mx],
-              "assistant": (t["assistant_response"] or "")[:mx], "timestamp": t["timestamp"]}
-             for t in turns_rows]
-    files = [dict(f) for f in conn.execute(
-        "SELECT file_path, tool_name, turn_index FROM session_files WHERE session_id = ?", (full_id,)
-    ).fetchall()]
-    refs = [dict(r) for r in conn.execute(
-        "SELECT ref_type, ref_value, turn_index FROM session_refs WHERE session_id = ?", (full_id,)
-    ).fetchall()]
-    cps = [{"n": c["checkpoint_number"], "title": c["title"], "overview": (c["overview"] or "")[:300]}
-           for c in conn.execute(
-        "SELECT checkpoint_number, title, overview FROM checkpoints "
-        "WHERE session_id = ? ORDER BY checkpoint_number", (full_id,)
-    ).fetchall()]
-    result = {
-        "id": full_id, "repository": row["repository"], "branch": row["branch"],
-        "summary": row["summary"], "created_at": row["created_at"],
-        "turns_count": len(turns_rows), "turns": turns,
-        "files": files, "refs": refs, "checkpoints": cps,
-    }
-    output(result, json_mode=getattr(args, 'json', False))
-    conn.close()
-    return 0
+    for provider in providers:
+        result = provider.get_session(
+            session_id=sid,
+            turns=getattr(args, "turns", None),
+            full=getattr(args, "full", False),
+        )
+        if result:
+            output(result, json_mode=getattr(args, "json", False))
+            return 0
+    print(f"No session found matching '{sid}'", file=sys.stderr)
+    return 1

--- a/src/session_recall/config.py
+++ b/src/session_recall/config.py
@@ -1,4 +1,5 @@
 """Configuration constants for auto-memory CLI."""
+
 import os
 from pathlib import Path
 
@@ -7,10 +8,19 @@ DB_PATH = os.environ.get(
     str(Path.home() / ".copilot" / "session-store.db"),
 )
 
+CLI_SESSION_STATE_ROOT = os.environ.get(
+    "SESSION_RECALL_CLI_STATE_ROOT",
+    str(Path.home() / ".copilot" / "session-state"),
+)
+
 TELEMETRY_PATH = os.environ.get(
     "SESSION_RECALL_TELEMETRY",
     str(Path.home() / ".copilot" / "scripts" / ".session-recall-stats.json"),
 )
+
+VSCODE_WORKSPACE_STORAGE = os.environ.get("SESSION_RECALL_VSCODE_STORAGE")
+JETBRAINS_SESSIONS_ROOT = os.environ.get("SESSION_RECALL_JETBRAINS_ROOT")
+NEOVIM_SESSIONS_ROOT = os.environ.get("SESSION_RECALL_NEOVIM_ROOT")
 
 RETRY_DELAYS_MS = [50, 150, 450]
 MAX_RETRIES = len(RETRY_DELAYS_MS)

--- a/src/session_recall/db/connect.py
+++ b/src/session_recall/db/connect.py
@@ -13,7 +13,6 @@ def connect_ro(db_path: str) -> sqlite3.Connection:
     if not pathlib.Path(db_path).exists():
         print(f"error: database not found: {db_path}", file=sys.stderr)
         sys.exit(4)
-    last_err: Exception | None = None
     for delay in [0] + RETRY_DELAYS_MS:
         if delay:
             time.sleep(delay * random.uniform(0.8, 1.2) / 1000)
@@ -28,7 +27,6 @@ def connect_ro(db_path: str) -> sqlite3.Connection:
             conn.execute("PRAGMA query_only = ON")
             return conn
         except sqlite3.OperationalError as e:
-            last_err = e
             if "locked" not in str(e).lower() and "busy" not in str(e).lower():
                 raise
     print("error: database is locked — another session-recall process may be running", file=sys.stderr)

--- a/src/session_recall/providers/__init__.py
+++ b/src/session_recall/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Storage providers for session data sources."""

--- a/src/session_recall/providers/base.py
+++ b/src/session_recall/providers/base.py
@@ -1,0 +1,50 @@
+"""Provider interface for session storage backends."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class StorageProvider(ABC):
+    """Common interface for all session storage providers."""
+
+    provider_id: str
+    provider_name: str
+
+    @abstractmethod
+    def is_available(self) -> bool:
+        """Return True when this provider can be used on this machine."""
+
+    @abstractmethod
+    def list_sessions(
+        self, repo: str | None, limit: int, days: int | None
+    ) -> list[dict]:
+        """List sessions in provider-native storage."""
+
+    @abstractmethod
+    def recent_files(
+        self, repo: str | None, limit: int, days: int | None
+    ) -> list[dict]:
+        """List recent files with session attribution if available."""
+
+    @abstractmethod
+    def list_checkpoints(
+        self, repo: str | None, limit: int, days: int | None
+    ) -> list[dict]:
+        """List checkpoint-style milestones if available."""
+
+    @abstractmethod
+    def search(
+        self, query: str, repo: str | None, limit: int, days: int | None
+    ) -> list[dict]:
+        """Search session content."""
+
+    @abstractmethod
+    def get_session(
+        self, session_id: str, turns: int | None, full: bool
+    ) -> dict | None:
+        """Return a single session payload, or None when not found."""
+
+    def schema_problems(self) -> list[str]:
+        """Return schema validation issues if meaningful for this provider."""
+        return []

--- a/src/session_recall/providers/common.py
+++ b/src/session_recall/providers/common.py
@@ -1,0 +1,31 @@
+"""Shared helpers for provider implementations."""
+
+from __future__ import annotations
+
+import datetime as _dt
+
+
+def utc_iso_from_ts(ts: float) -> str:
+    """Convert POSIX timestamp to UTC ISO8601."""
+    return _dt.datetime.fromtimestamp(ts, tz=_dt.timezone.utc).isoformat()
+
+
+def is_within_days(iso_ts: str | None, days: int | None) -> bool:
+    """Check if timestamp string falls inside the requested day window."""
+    if days is None:
+        return True
+    if not iso_ts:
+        return False
+    try:
+        parsed = _dt.datetime.fromisoformat(iso_ts.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=_dt.timezone.utc)
+    cutoff = _dt.datetime.now(tz=_dt.timezone.utc) - _dt.timedelta(days=days)
+    return parsed >= cutoff
+
+
+def short_id(sid: str) -> str:
+    """Consistent short id representation."""
+    return sid[:8]

--- a/src/session_recall/providers/copilot_cli.py
+++ b/src/session_recall/providers/copilot_cli.py
@@ -1,0 +1,558 @@
+"""Copilot CLI SQLite provider."""
+
+from __future__ import annotations
+
+import re
+import json
+from pathlib import Path
+
+from ..db.connect import connect_ro
+from ..db.schema_check import schema_check
+from ..util.detect_repo import detect_repo_for_cwd
+from .base import StorageProvider
+from .common import is_within_days, short_id, utc_iso_from_ts
+
+_SID_RE = re.compile(r"^[0-9a-fA-F-]{4,}$")
+
+
+class CopilotCliProvider(StorageProvider):
+    provider_id = "cli"
+    provider_name = "Copilot CLI"
+
+    def __init__(self, db_path: str, state_root: str) -> None:
+        self.db_path = db_path
+        self.state_root = Path(state_root)
+
+    def _has_db(self) -> bool:
+        return Path(self.db_path).exists()
+
+    def _state_files(self) -> list[Path]:
+        if not self.state_root.exists():
+            return []
+        files = list(self.state_root.glob("*/events.jsonl"))
+        files.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+        return files
+
+    def is_available(self) -> bool:
+        return self._has_db() or bool(self._state_files())
+
+    def schema_problems(self) -> list[str]:
+        if not self._has_db():
+            return []
+        conn = connect_ro(self.db_path)
+        try:
+            return schema_check(conn)
+        finally:
+            conn.close()
+
+    def list_sessions(
+        self, repo: str | None, limit: int, days: int | None
+    ) -> list[dict]:
+        if not self._has_db():
+            return self._state_list_sessions(repo=repo, limit=limit, days=days)
+        conn = connect_ro(self.db_path)
+        try:
+            days_arg = f"-{days or 30} days"
+            if repo and repo != "all":
+                rows = conn.execute(
+                    """
+                    SELECT s.id, s.repository, s.branch, s.summary, s.created_at, s.updated_at,
+                           (SELECT COUNT(*) FROM turns t WHERE t.session_id = s.id) as turns_count,
+                           (SELECT COUNT(*) FROM session_files f WHERE f.session_id = s.id) as files_count
+                    FROM sessions s WHERE s.repository = ? AND s.created_at >= datetime('now', ?)
+                    ORDER BY s.created_at DESC LIMIT ?
+                    """,
+                    (repo, days_arg, limit),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    """
+                    SELECT s.id, s.repository, s.branch, s.summary, s.created_at, s.updated_at,
+                           (SELECT COUNT(*) FROM turns t WHERE t.session_id = s.id) as turns_count,
+                           (SELECT COUNT(*) FROM session_files f WHERE f.session_id = s.id) as files_count
+                    FROM sessions s WHERE s.created_at >= datetime('now', ?)
+                    ORDER BY s.created_at DESC LIMIT ?
+                    """,
+                    (days_arg, limit),
+                ).fetchall()
+            return [
+                {
+                    "provider": self.provider_id,
+                    "id_short": short_id(r["id"]),
+                    "id_full": r["id"],
+                    "repository": r["repository"],
+                    "branch": r["branch"],
+                    "summary": r["summary"],
+                    "date": r["created_at"][:10] if r["created_at"] else None,
+                    "created_at": r["created_at"],
+                    "turns_count": r["turns_count"],
+                    "files_count": r["files_count"],
+                }
+                for r in rows
+            ]
+        finally:
+            conn.close()
+
+    def recent_files(
+        self, repo: str | None, limit: int, days: int | None
+    ) -> list[dict]:
+        if not self._has_db():
+            return []
+        conn = connect_ro(self.db_path)
+        try:
+            date_filter = " AND sf.first_seen_at >= datetime('now', ?)" if days else ""
+            date_param = (f"-{days} days",) if days else ()
+            base = """
+                SELECT sf.file_path, sf.tool_name, sf.first_seen_at,
+                       sf.session_id, s.summary
+                FROM session_files sf
+                JOIN sessions s ON s.id = sf.session_id
+            """
+            if repo and repo != "all":
+                sql = (
+                    base
+                    + f" WHERE s.repository = ?{date_filter} ORDER BY sf.first_seen_at DESC LIMIT ?"
+                )
+                rows = conn.execute(sql, (repo, *date_param, limit)).fetchall()
+            else:
+                where = f" WHERE 1=1{date_filter}" if days else ""
+                sql = base + where + " ORDER BY sf.first_seen_at DESC LIMIT ?"
+                rows = conn.execute(sql, (*date_param, limit)).fetchall()
+            return [
+                {
+                    "provider": self.provider_id,
+                    "file_path": r["file_path"],
+                    "tool_name": r["tool_name"],
+                    "date": (r["first_seen_at"] or "")[:10],
+                    "session_id": short_id(r["session_id"]),
+                    "session_summary": r["summary"],
+                }
+                for r in rows
+            ]
+        finally:
+            conn.close()
+
+    def list_checkpoints(
+        self, repo: str | None, limit: int, days: int | None
+    ) -> list[dict]:
+        if not self._has_db():
+            return []
+        conn = connect_ro(self.db_path)
+        try:
+            date_filter = " AND c.created_at >= datetime('now', ?)" if days else ""
+            date_param = (f"-{days} days",) if days else ()
+            base = """
+                SELECT c.checkpoint_number, c.title, c.overview, c.created_at,
+                       c.session_id, s.summary as session_summary
+                FROM checkpoints c
+                JOIN sessions s ON s.id = c.session_id
+            """
+            if repo and repo != "all":
+                sql = (
+                    base
+                    + f" WHERE s.repository = ?{date_filter} ORDER BY c.created_at DESC LIMIT ?"
+                )
+                rows = conn.execute(sql, (repo, *date_param, limit)).fetchall()
+            else:
+                where = f" WHERE 1=1{date_filter}" if days else ""
+                sql = base + where + " ORDER BY c.created_at DESC LIMIT ?"
+                rows = conn.execute(sql, (*date_param, limit)).fetchall()
+            return [
+                {
+                    "provider": self.provider_id,
+                    "checkpoint_number": r["checkpoint_number"],
+                    "title": r["title"],
+                    "overview": (r["overview"] or "")[:300],
+                    "date": (r["created_at"] or "")[:10],
+                    "session_id": short_id(r["session_id"]),
+                    "session_summary": r["session_summary"],
+                }
+                for r in rows
+            ]
+        finally:
+            conn.close()
+
+    def search(
+        self, query: str, repo: str | None, limit: int, days: int | None
+    ) -> list[dict]:
+        if not self._has_db():
+            return self._state_search(query=query, repo=repo, limit=limit, days=days)
+        from ..commands.search import sanitize_fts5_query
+
+        fts_query = sanitize_fts5_query(query)
+        if fts_query is None:
+            return []
+        conn = connect_ro(self.db_path)
+        try:
+            date_clause = " AND s.created_at >= datetime('now', ?)" if days else ""
+            date_param = (f"-{days} days",) if days else ()
+            if repo and repo != "all":
+                sql = (
+                    """
+                    SELECT si.content, si.session_id, si.source_type,
+                           s.summary, s.created_at, s.repository
+                    FROM search_index si JOIN sessions s ON s.id = si.session_id
+                    WHERE search_index MATCH ? AND s.repository = ?
+                    """
+                    + date_clause
+                    + " ORDER BY rank LIMIT ?"
+                )
+                rows = conn.execute(
+                    sql, (fts_query, repo, *date_param, limit)
+                ).fetchall()
+            else:
+                sql = (
+                    """
+                    SELECT si.content, si.session_id, si.source_type,
+                           s.summary, s.created_at, s.repository
+                    FROM search_index si JOIN sessions s ON s.id = si.session_id
+                    WHERE search_index MATCH ?
+                    """
+                    + date_clause
+                    + " ORDER BY rank LIMIT ?"
+                )
+                rows = conn.execute(sql, (fts_query, *date_param, limit)).fetchall()
+
+            return [
+                {
+                    "provider": self.provider_id,
+                    "session_id": short_id(r["session_id"]),
+                    "session_id_full": r["session_id"],
+                    "source_type": r["source_type"],
+                    "summary": r["summary"],
+                    "repository": r["repository"],
+                    "date": (r["created_at"] or "")[:10],
+                    "content": (r["content"] or "")[:500],
+                }
+                for r in rows
+            ]
+        finally:
+            conn.close()
+
+    def get_session(
+        self, session_id: str, turns: int | None, full: bool
+    ) -> dict | None:
+        if not self._has_db():
+            return self._state_get_session(
+                session_id=session_id, turns=turns, full=full
+            )
+        if not _SID_RE.match(session_id) or not session_id.replace("-", ""):
+            return None
+        sid = session_id.lower()
+        conn = connect_ro(self.db_path)
+        try:
+            row = conn.execute(
+                "SELECT * FROM sessions WHERE id = ? OR id LIKE ?",
+                (sid, f"{sid}%"),
+            ).fetchone()
+            if not row:
+                return None
+            full_id = row["id"]
+            if turns is not None:
+                turns_rows = conn.execute(
+                    "SELECT turn_index, user_message, assistant_response, timestamp "
+                    "FROM turns WHERE session_id = ? ORDER BY turn_index LIMIT ?",
+                    (full_id, turns),
+                ).fetchall()
+            else:
+                turns_rows = conn.execute(
+                    "SELECT turn_index, user_message, assistant_response, timestamp "
+                    "FROM turns WHERE session_id = ? ORDER BY turn_index",
+                    (full_id,),
+                ).fetchall()
+            mx = 99999 if full else 500
+            turn_payload = [
+                {
+                    "idx": t["turn_index"],
+                    "user": (t["user_message"] or "")[:mx],
+                    "assistant": (t["assistant_response"] or "")[:mx],
+                    "timestamp": t["timestamp"],
+                }
+                for t in turns_rows
+            ]
+            files = [
+                dict(f)
+                for f in conn.execute(
+                    "SELECT file_path, tool_name, turn_index FROM session_files WHERE session_id = ?",
+                    (full_id,),
+                ).fetchall()
+            ]
+            refs = [
+                dict(r)
+                for r in conn.execute(
+                    "SELECT ref_type, ref_value, turn_index FROM session_refs WHERE session_id = ?",
+                    (full_id,),
+                ).fetchall()
+            ]
+            checkpoints = [
+                {
+                    "n": c["checkpoint_number"],
+                    "title": c["title"],
+                    "overview": (c["overview"] or "")[:300],
+                }
+                for c in conn.execute(
+                    "SELECT checkpoint_number, title, overview FROM checkpoints "
+                    "WHERE session_id = ? ORDER BY checkpoint_number",
+                    (full_id,),
+                ).fetchall()
+            ]
+            return {
+                "provider": self.provider_id,
+                "id": full_id,
+                "repository": row["repository"],
+                "branch": row["branch"],
+                "summary": row["summary"],
+                "created_at": row["created_at"],
+                "turns_count": len(turns_rows),
+                "turns": turn_payload,
+                "files": files,
+                "refs": refs,
+                "checkpoints": checkpoints,
+            }
+        finally:
+            conn.close()
+
+    def _parse_state_session(self, file_path: Path) -> dict:
+        session_id = file_path.parent.name
+        created_at = None
+        cwd = None
+        git_root = None
+        repo_from_context = None
+        candidate_paths: list[str] = []
+        turns: list[dict] = []
+        last_text = None
+        try:
+            with file_path.open("r", encoding="utf-8", errors="replace") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        event = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    etype = event.get("type")
+                    data = event.get("data") or {}
+                    ts = event.get("timestamp")
+
+                    if etype == "session.start":
+                        session_id = data.get("sessionId") or session_id
+                        created_at = created_at or ts
+                        context = data.get("context") or {}
+                        if isinstance(context, dict):
+                            cwd = context.get("cwd") or cwd
+                            git_root = context.get("gitRoot") or git_root
+                            if isinstance(context.get("repository"), str):
+                                repo_from_context = (
+                                    context.get("repository") or repo_from_context
+                                )
+                    elif etype == "tool.execution_start":
+                        candidate_paths.extend(
+                            _extract_path_candidates(data.get("arguments"))
+                        )
+
+                    text = None
+                    role = None
+                    if etype == "user.message":
+                        text = data.get("content") or data.get("transformedContent")
+                        role = "user"
+                    elif etype == "assistant.message":
+                        text = data.get("content")
+                        role = "assistant"
+
+                    if not text:
+                        continue
+                    text = str(text).strip()
+                    if not text or text == last_text:
+                        continue
+                    last_text = text
+                    turns.append(
+                        {
+                            "idx": len(turns),
+                            "user": text if role == "user" else "",
+                            "assistant": text if role == "assistant" else "",
+                            "timestamp": ts,
+                        }
+                    )
+        except OSError:
+            pass
+
+        summary = ""
+        for t in turns:
+            if t.get("user"):
+                summary = t["user"].splitlines()[0][:120]
+                break
+        if not summary:
+            summary = file_path.name
+
+        created_str = ""
+        if isinstance(created_at, str) and created_at:
+            created_str = created_at
+        else:
+            created_str = utc_iso_from_ts(file_path.stat().st_mtime)
+
+        repository = repo_from_context
+        if not repository:
+            for maybe_repo_path in (git_root, cwd, *_dedupe_paths(candidate_paths)):
+                if not isinstance(maybe_repo_path, str) or not maybe_repo_path:
+                    continue
+                repository = _detect_repo_for_path(maybe_repo_path)
+                if repository:
+                    break
+        if not repository:
+            repository = _local_workspace_label(
+                git_root or cwd or next(iter(_dedupe_paths(candidate_paths)), None)
+            )
+
+        return {
+            "provider": self.provider_id,
+            "id_short": short_id(session_id),
+            "id_full": session_id,
+            "repository": repository or "unknown",
+            "branch": "unknown",
+            "summary": summary,
+            "date": created_str[:10] if created_str else "",
+            "created_at": created_str,
+            "turns_count": len(turns),
+            "files_count": 0,
+            "_turns": turns,
+            "_path": str(file_path),
+        }
+
+    def _state_list_sessions(
+        self, repo: str | None, limit: int, days: int | None
+    ) -> list[dict]:
+        rows = []
+        for fp in self._state_files():
+            parsed = self._parse_state_session(fp)
+            if repo and repo != "all" and parsed.get("repository") != repo:
+                continue
+            if not is_within_days(parsed.get("created_at"), days):
+                continue
+            rows.append({k: v for k, v in parsed.items() if not k.startswith("_")})
+            if len(rows) >= limit:
+                break
+        return rows
+
+    def _state_search(
+        self, query: str, repo: str | None, limit: int, days: int | None
+    ) -> list[dict]:
+        q = query.strip().lower()
+        if not q:
+            return []
+        out = []
+        for fp in self._state_files():
+            parsed = self._parse_state_session(fp)
+            if repo and repo != "all" and parsed.get("repository") != repo:
+                continue
+            if not is_within_days(parsed.get("created_at"), days):
+                continue
+            for t in parsed.get("_turns", []):
+                content = f"{t.get('user', '')}\n{t.get('assistant', '')}".strip()
+                if q not in content.lower():
+                    continue
+                out.append(
+                    {
+                        "provider": self.provider_id,
+                        "session_id": short_id(parsed["id_full"]),
+                        "session_id_full": parsed["id_full"],
+                        "source_type": "turn",
+                        "summary": parsed["summary"],
+                        "repository": parsed["repository"],
+                        "date": parsed["date"],
+                        "content": content[:500],
+                    }
+                )
+                if len(out) >= limit:
+                    return out
+        return out
+
+    def _state_get_session(
+        self, session_id: str, turns: int | None, full: bool
+    ) -> dict | None:
+        sid = session_id.strip().lower()
+        for fp in self._state_files():
+            parsed = self._parse_state_session(fp)
+            full_id = str(parsed["id_full"]).lower()
+            if not (full_id == sid or full_id.startswith(sid)):
+                continue
+            turn_rows = parsed.get("_turns", [])
+            if turns is not None:
+                turn_rows = turn_rows[:turns]
+            if not full:
+                turn_rows = [
+                    {
+                        "idx": t["idx"],
+                        "user": (t.get("user") or "")[:500],
+                        "assistant": (t.get("assistant") or "")[:500],
+                        "timestamp": t.get("timestamp"),
+                    }
+                    for t in turn_rows
+                ]
+            return {
+                "provider": self.provider_id,
+                "id": parsed["id_full"],
+                "repository": parsed["repository"],
+                "branch": parsed["branch"],
+                "summary": parsed["summary"],
+                "created_at": parsed["created_at"],
+                "turns_count": len(turn_rows),
+                "turns": turn_rows,
+                "files": [],
+                "refs": [],
+                "checkpoints": [],
+            }
+        return None
+
+
+_PATH_HINT_KEYS = {
+    "path",
+    "cwd",
+    "filePath",
+    "workspaceFolder",
+    "dirPath",
+    "resourcePath",
+    "includePattern",
+}
+
+
+def _extract_path_candidates(obj: object) -> list[str]:
+    paths: list[str] = []
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if (
+                key in _PATH_HINT_KEYS
+                and isinstance(value, str)
+                and value.strip().startswith(("/", "~"))
+            ):
+                paths.append(value.strip())
+            paths.extend(_extract_path_candidates(value))
+    elif isinstance(obj, list):
+        for item in obj:
+            paths.extend(_extract_path_candidates(item))
+    return paths
+
+
+def _dedupe_paths(paths: list[str]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for path in paths:
+        if path in seen:
+            continue
+        seen.add(path)
+        out.append(path)
+    return out
+
+
+def _detect_repo_for_path(path_str: str) -> str | None:
+    path = Path(path_str).expanduser()
+    candidate = path if path.is_dir() else path.parent
+    return detect_repo_for_cwd(str(candidate))
+
+
+def _local_workspace_label(path_str: str | None) -> str | None:
+    if not path_str:
+        return None
+    path = Path(path_str).expanduser()
+    candidate = path if path.is_dir() else path.parent
+    return f"local:{candidate}"

--- a/src/session_recall/providers/discovery.py
+++ b/src/session_recall/providers/discovery.py
@@ -1,0 +1,37 @@
+"""Provider discovery and selection."""
+
+from __future__ import annotations
+
+from ..config import (
+    CLI_SESSION_STATE_ROOT,
+    JETBRAINS_SESSIONS_ROOT,
+    NEOVIM_SESSIONS_ROOT,
+    VSCODE_WORKSPACE_STORAGE,
+)
+from .base import StorageProvider
+from .copilot_cli import CopilotCliProvider
+from .file_backends import JetBrainsProvider, NeovimProvider, VSCodeProvider
+
+
+def discover_providers(db_path: str) -> list[StorageProvider]:
+    """Build the provider list and keep only available ones."""
+    candidates: list[StorageProvider] = [
+        CopilotCliProvider(db_path=db_path, state_root=CLI_SESSION_STATE_ROOT),
+        VSCodeProvider(root_override=VSCODE_WORKSPACE_STORAGE),
+        JetBrainsProvider(root_override=JETBRAINS_SESSIONS_ROOT),
+        NeovimProvider(root_override=NEOVIM_SESSIONS_ROOT),
+    ]
+    return [p for p in candidates if p.is_available()]
+
+
+def get_active_providers(selected: str | None, db_path: str) -> list[StorageProvider]:
+    """Resolve user-selected provider scope from discovered backends."""
+    providers = discover_providers(db_path)
+    if not selected or selected == "all":
+        return providers
+    selected = selected.lower()
+    filtered = [p for p in providers if p.provider_id == selected]
+    if not filtered:
+        known = ", ".join(sorted({p.provider_id for p in providers})) or "none"
+        raise ValueError(f"provider '{selected}' is unavailable (available: {known})")
+    return filtered

--- a/src/session_recall/providers/file_backends.py
+++ b/src/session_recall/providers/file_backends.py
@@ -1,0 +1,379 @@
+"""File-backed providers for IDE/session JSON logs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from .base import StorageProvider
+from .common import is_within_days, short_id, utc_iso_from_ts
+
+
+class _FileSessionProvider(StorageProvider):
+    provider_name = "File Sessions"
+    _MAX_PARSE_LINES = 5000
+    _MAX_LINE_CHARS = 500_000
+
+    def __init__(
+        self, provider_id: str, roots: list[Path], patterns: list[str]
+    ) -> None:
+        self.provider_id = provider_id
+        self._roots = roots
+        self._patterns = patterns
+
+    def is_available(self) -> bool:
+        return any(root.exists() for root in self._roots)
+
+    def _iter_files(self) -> list[Path]:
+        files: list[Path] = []
+        seen: set[Path] = set()
+        for root in self._roots:
+            if not root.exists():
+                continue
+            for pattern in self._patterns:
+                for file_path in root.glob(pattern):
+                    if not file_path.is_file():
+                        continue
+                    resolved = file_path.resolve()
+                    if resolved in seen:
+                        continue
+                    seen.add(resolved)
+                    files.append(resolved)
+        files.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+        return files
+
+    def _session_id(self, file_path: Path) -> str:
+        digest = hashlib.sha1(str(file_path).encode("utf-8")).hexdigest()
+        return f"{self.provider_id}:{digest}"
+
+    def _session_from_file(self, file_path: Path) -> dict:
+        sid = self._session_id(file_path)
+        mtime = file_path.stat().st_mtime
+        created = utc_iso_from_ts(mtime)
+        turns = self._parse_turns(file_path)
+        summary = _best_summary(turns, fallback=file_path.name)
+        return {
+            "provider": self.provider_id,
+            "id_short": short_id(sid),
+            "id_full": sid,
+            "repository": "unknown",
+            "branch": "unknown",
+            "summary": summary,
+            "date": created[:10],
+            "created_at": created,
+            "turns_count": len(turns),
+            "files_count": 1,
+            "_path": str(file_path),
+            "_turns": turns,
+        }
+
+    def _parse_turns(self, file_path: Path) -> list[dict]:
+        turns: list[dict] = []
+        last_text = None
+        try:
+            with file_path.open("r", encoding="utf-8", errors="replace") as f:
+                for idx, line in enumerate(f):
+                    if idx >= self._MAX_PARSE_LINES:
+                        break
+                    line = line.strip()
+                    if not line:
+                        continue
+                    if len(line) > self._MAX_LINE_CHARS:
+                        # Skip pathological lines to keep recall responsive.
+                        continue
+                    try:
+                        obj = json.loads(line)
+                    except (
+                        json.JSONDecodeError,
+                        RecursionError,
+                        TypeError,
+                        ValueError,
+                    ):
+                        continue
+                    text = _extract_text(obj)
+                    if not text:
+                        continue
+                    text = text.strip()
+                    if not text or text == last_text:
+                        continue
+                    last_text = text
+                    role = _extract_role(obj)
+                    turns.append(
+                        {
+                            "idx": idx,
+                            "user": text if role == "user" else "",
+                            "assistant": text if role != "user" else "",
+                            "timestamp": (
+                                obj.get("timestamp") if isinstance(obj, dict) else None
+                            ),
+                        }
+                    )
+        except OSError:
+            return []
+        return turns
+
+    def list_sessions(
+        self, repo: str | None, limit: int, days: int | None
+    ) -> list[dict]:
+        sessions: list[dict] = []
+        for fp in self._iter_files():
+            sess = self._session_from_file(fp)
+            if not is_within_days(sess.get("created_at"), days):
+                continue
+            sessions.append({k: v for k, v in sess.items() if not k.startswith("_")})
+            if len(sessions) >= limit:
+                break
+        return sessions
+
+    def recent_files(
+        self, repo: str | None, limit: int, days: int | None
+    ) -> list[dict]:
+        rows: list[dict] = []
+        for fp in self._iter_files():
+            created = utc_iso_from_ts(fp.stat().st_mtime)
+            if not is_within_days(created, days):
+                continue
+            sid = self._session_id(fp)
+            rows.append(
+                {
+                    "provider": self.provider_id,
+                    "file_path": str(fp),
+                    "tool_name": "json-log",
+                    "date": created[:10],
+                    "session_id": short_id(sid),
+                    "session_summary": fp.name,
+                }
+            )
+            if len(rows) >= limit:
+                break
+        return rows
+
+    def list_checkpoints(
+        self, repo: str | None, limit: int, days: int | None
+    ) -> list[dict]:
+        # File-backed providers typically don't expose checkpoints as first-class records.
+        return []
+
+    def search(
+        self, query: str, repo: str | None, limit: int, days: int | None
+    ) -> list[dict]:
+        q = query.strip().lower()
+        if not q:
+            return []
+        matches: list[dict] = []
+        for fp in self._iter_files():
+            sess = self._session_from_file(fp)
+            if not is_within_days(sess.get("created_at"), days):
+                continue
+            for turn in sess.get("_turns", []):
+                blob = f"{turn.get('user', '')}\n{turn.get('assistant', '')}".lower()
+                if q not in blob:
+                    continue
+                matches.append(
+                    {
+                        "provider": self.provider_id,
+                        "session_id": short_id(sess["id_full"]),
+                        "session_id_full": sess["id_full"],
+                        "source_type": "turn",
+                        "summary": sess["summary"],
+                        "repository": sess["repository"],
+                        "date": sess["date"],
+                        "content": blob[:500],
+                    }
+                )
+                if len(matches) >= limit:
+                    return matches
+        return matches
+
+    def get_session(
+        self, session_id: str, turns: int | None, full: bool
+    ) -> dict | None:
+        sid = session_id.strip().lower()
+        for fp in self._iter_files():
+            sess = self._session_from_file(fp)
+            full_id = sess["id_full"].lower()
+            if not (full_id == sid or full_id.startswith(sid)):
+                continue
+            turn_rows = sess.get("_turns", [])
+            if turns is not None:
+                turn_rows = turn_rows[:turns]
+            if not full:
+                turn_rows = [
+                    {
+                        "idx": t["idx"],
+                        "user": (t.get("user") or "")[:500],
+                        "assistant": (t.get("assistant") or "")[:500],
+                        "timestamp": t.get("timestamp"),
+                    }
+                    for t in turn_rows
+                ]
+            return {
+                "provider": self.provider_id,
+                "id": sess["id_full"],
+                "repository": sess["repository"],
+                "branch": sess["branch"],
+                "summary": sess["summary"],
+                "created_at": sess["created_at"],
+                "turns_count": len(turn_rows),
+                "turns": turn_rows,
+                "files": [
+                    {
+                        "file_path": sess["_path"],
+                        "tool_name": "json-log",
+                        "turn_index": 0,
+                    }
+                ],
+                "refs": [],
+                "checkpoints": [],
+            }
+        return None
+
+
+class VSCodeProvider(_FileSessionProvider):
+    provider_name = "VS Code"
+
+    def __init__(self, root_override: str | None = None) -> None:
+        home = Path.home()
+        if root_override:
+            roots = [Path(root_override).expanduser()]
+        else:
+            roots = [
+                home / ".config" / "Code" / "User" / "workspaceStorage",
+                home
+                / ".var"
+                / "app"
+                / "com.visualstudio.code"
+                / "config"
+                / "Code"
+                / "User"
+                / "workspaceStorage",
+                home
+                / "snap"
+                / "code"
+                / "current"
+                / ".config"
+                / "Code"
+                / "User"
+                / "workspaceStorage",
+            ]
+        super().__init__("vscode", roots, ["**/chatSessions/*.jsonl"])
+
+
+class JetBrainsProvider(_FileSessionProvider):
+    provider_name = "JetBrains"
+
+    def __init__(self, root_override: str | None = None) -> None:
+        home = Path.home()
+        roots = (
+            [Path(root_override).expanduser()]
+            if root_override
+            else [home / ".config" / "github-copilot"]
+        )
+        super().__init__(
+            "jetbrains",
+            roots,
+            ["chat-sessions/*", "chat-agent-sessions/*", "chat-edit-sessions/*"],
+        )
+
+
+class NeovimProvider(_FileSessionProvider):
+    provider_name = "Neovim"
+
+    def __init__(self, root_override: str | None = None) -> None:
+        home = Path.home()
+        if root_override:
+            roots = [Path(root_override).expanduser()]
+        else:
+            roots = [
+                home / ".config" / "github-copilot",
+                home / ".local" / "share" / "nvim",
+            ]
+        super().__init__("neovim", roots, ["**/*chat*.json", "**/*chat*.jsonl"])
+
+
+def _extract_role(obj: object) -> str:
+    if not isinstance(obj, dict):
+        return "assistant"
+    # VS Code chatSessions uses kind/k/v records for state diffs.
+    if obj.get("kind") == 1:
+        k = obj.get("k")
+        if (
+            isinstance(k, list)
+            and len(k) >= 2
+            and k[0] == "inputState"
+            and k[1] == "inputText"
+        ):
+            return "user"
+    role = obj.get("role")
+    if isinstance(role, str):
+        return role.lower()
+    kind = obj.get("type")
+    if isinstance(kind, str):
+        return "user" if "user" in kind.lower() else "assistant"
+    return "assistant"
+
+
+def _extract_text(obj: object) -> str:
+    if isinstance(obj, str):
+        return obj
+    if isinstance(obj, list):
+        return " ".join(x for x in (_extract_text(i) for i in obj) if x)
+    if not isinstance(obj, dict):
+        return ""
+
+    # VS Code chatSessions incremental state update format.
+    if obj.get("kind") == 1:
+        k = obj.get("k")
+        v = obj.get("v")
+        if (
+            isinstance(k, list)
+            and len(k) >= 2
+            and k[0] == "inputState"
+            and k[1] == "inputText"
+        ):
+            return v if isinstance(v, str) else ""
+
+    # Some chatSessions have requests payload with user message text.
+    if obj.get("kind") == 2 and isinstance(obj.get("v"), list):
+        for item in obj.get("v"):
+            if not isinstance(item, dict):
+                continue
+            message = item.get("message")
+            if isinstance(message, str) and message.strip():
+                return message
+
+    candidates = [
+        obj.get("text"),
+        obj.get("content"),
+        obj.get("message"),
+        obj.get("value"),
+    ]
+    for c in candidates:
+        t = _extract_text(c)
+        if t:
+            return t
+
+    for key in ("messages", "parts", "items", "payload"):
+        if key in obj:
+            t = _extract_text(obj[key])
+            if t:
+                return t
+    return ""
+
+
+def _best_summary(turns: list[dict], fallback: str) -> str:
+    """Pick the first meaningful user/assistant line for list summaries."""
+    for turn in turns:
+        for key in ("user", "assistant"):
+            raw = str(turn.get(key) or "").strip()
+            if not raw:
+                continue
+            first_line = raw.splitlines()[0].strip()
+            if len(first_line) < 4:
+                continue
+            # Skip low-signal markdown/mention noise.
+            if first_line in {"@", "```", "---"}:
+                continue
+            return first_line[:120]
+    return fallback

--- a/src/session_recall/tests/test_dim_disclosure.py
+++ b/src/session_recall/tests/test_dim_disclosure.py
@@ -1,7 +1,6 @@
 """Tests for health/dim_disclosure.py — three-state tier, transitions, sample gates."""
 import json
 from datetime import datetime, timedelta, timezone
-import pytest
 from session_recall.health import dim_disclosure
 
 

--- a/src/session_recall/tests/test_health_schema_multistorage.py
+++ b/src/session_recall/tests/test_health_schema_multistorage.py
@@ -1,0 +1,82 @@
+"""Tests for provider-aware health and schema-check commands."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+
+class _FakeProvider:
+    def __init__(
+        self,
+        provider_id: str,
+        provider_name: str,
+        problems: list[str],
+        session_count: int,
+    ) -> None:
+        self.provider_id = provider_id
+        self.provider_name = provider_name
+        self._problems = problems
+        self._session_count = session_count
+
+    def schema_problems(self) -> list[str]:
+        return self._problems
+
+    def list_sessions(
+        self, repo: str | None, limit: int, days: int | None
+    ) -> list[dict]:
+        return [{"id": f"s{i}"} for i in range(min(self._session_count, limit))]
+
+
+def test_schema_check_provider_ok_json(monkeypatch, capsys):
+    from session_recall.commands import schema_check_cmd
+
+    providers = [_FakeProvider("cli", "Copilot CLI", [], 1)]
+    monkeypatch.setattr(
+        schema_check_cmd, "get_active_providers", lambda selected, db_path: providers
+    )
+
+    args = argparse.Namespace(json=True, provider="all")
+    rc = schema_check_cmd.run(args)
+
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is True
+    assert out["providers"][0]["provider"] == "cli"
+
+
+def test_schema_check_provider_failure_json(monkeypatch, capsys):
+    from session_recall.commands import schema_check_cmd
+
+    providers = [_FakeProvider("cli", "Copilot CLI", ["MISSING TABLE: sessions"], 0)]
+    monkeypatch.setattr(
+        schema_check_cmd, "get_active_providers", lambda selected, db_path: providers
+    )
+
+    args = argparse.Namespace(json=True, provider="all")
+    rc = schema_check_cmd.run(args)
+
+    assert rc == 2
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is False
+    assert any("MISSING TABLE" in p for p in out["problems"])
+
+
+def test_health_provider_fallback_mode_json(monkeypatch, capsys):
+    from session_recall.commands import health
+
+    providers = [_FakeProvider("vscode", "VS Code", [], 3)]
+    monkeypatch.setattr(
+        health, "get_active_providers", lambda selected, db_path: providers
+    )
+    monkeypatch.setattr(health, "DB_PATH", "/tmp/definitely-missing-auto-memory.db")
+
+    args = argparse.Namespace(json=True, provider="all")
+    rc = health.run(args)
+
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["storage_mode"] == "provider-fallback"
+    names = [d["name"] for d in out["dims"]]
+    assert "SQLite Health Core" in names
+    assert "Provider:vscode" in names

--- a/src/session_recall/tests/test_list_sessions.py
+++ b/src/session_recall/tests/test_list_sessions.py
@@ -1,4 +1,5 @@
 """Tests for commands/list_sessions.py — session listing logic."""
+
 import sqlite3
 import tempfile
 import os
@@ -15,26 +16,44 @@ def _create_test_db() -> str:
     path = f.name
     f.close()
     conn = sqlite3.connect(path)
-    conn.execute("""CREATE TABLE sessions (
+    conn.execute(
+        """CREATE TABLE sessions (
         id TEXT PRIMARY KEY, cwd TEXT, repository TEXT, branch TEXT,
-        summary TEXT, created_at TEXT, updated_at TEXT, host_type TEXT)""")
-    conn.execute("""CREATE TABLE turns (
+        summary TEXT, created_at TEXT, updated_at TEXT, host_type TEXT)"""
+    )
+    conn.execute(
+        """CREATE TABLE turns (
         id INTEGER PRIMARY KEY, session_id TEXT, turn_index INTEGER,
-        user_message TEXT, assistant_response TEXT, timestamp TEXT)""")
-    conn.execute("""CREATE TABLE session_files (
+        user_message TEXT, assistant_response TEXT, timestamp TEXT)"""
+    )
+    conn.execute(
+        """CREATE TABLE session_files (
         id INTEGER PRIMARY KEY, session_id TEXT, file_path TEXT,
-        tool_name TEXT, turn_index INTEGER, first_seen_at TEXT)""")
-    conn.execute("""CREATE TABLE session_refs (
+        tool_name TEXT, turn_index INTEGER, first_seen_at TEXT)"""
+    )
+    conn.execute(
+        """CREATE TABLE session_refs (
         id INTEGER PRIMARY KEY, session_id TEXT, ref_type TEXT,
-        ref_value TEXT, turn_index INTEGER, created_at TEXT)""")
-    conn.execute("""CREATE TABLE checkpoints (
+        ref_value TEXT, turn_index INTEGER, created_at TEXT)"""
+    )
+    conn.execute(
+        """CREATE TABLE checkpoints (
         id INTEGER PRIMARY KEY, session_id TEXT, checkpoint_number INTEGER,
-        title TEXT, overview TEXT, created_at TEXT)""")
+        title TEXT, overview TEXT, created_at TEXT)"""
+    )
     # Insert test data
-    conn.execute("INSERT INTO sessions VALUES ('s1', '/tmp', 'owner/repo', 'main', 'Test session 1', datetime('now'), datetime('now'), 'local')")
-    conn.execute("INSERT INTO sessions VALUES ('s2', '/tmp', 'owner/repo', 'main', 'Test session 2', datetime('now', '-1 day'), datetime('now'), 'local')")
-    conn.execute("INSERT INTO sessions VALUES ('s3', '/tmp', 'other/repo', 'dev', 'Other repo', datetime('now'), datetime('now'), 'local')")
-    conn.execute("INSERT INTO turns VALUES (1, 's1', 0, 'hello', 'hi', datetime('now'))")
+    conn.execute(
+        "INSERT INTO sessions VALUES ('s1', '/tmp', 'owner/repo', 'main', 'Test session 1', datetime('now'), datetime('now'), 'local')"
+    )
+    conn.execute(
+        "INSERT INTO sessions VALUES ('s2', '/tmp', 'owner/repo', 'main', 'Test session 2', datetime('now', '-1 day'), datetime('now'), 'local')"
+    )
+    conn.execute(
+        "INSERT INTO sessions VALUES ('s3', '/tmp', 'other/repo', 'dev', 'Other repo', datetime('now'), datetime('now'), 'local')"
+    )
+    conn.execute(
+        "INSERT INTO turns VALUES (1, 's1', 0, 'hello', 'hi', datetime('now'))"
+    )
     conn.execute("INSERT INTO turns VALUES (2, 's1', 1, 'q2', 'a2', datetime('now'))")
     conn.commit()
     conn.close()
@@ -45,9 +64,15 @@ def test_list_filters_by_repo():
     """List should only return sessions for the specified repo."""
     path = _create_test_db()
     try:
-        with patch("session_recall.commands.list_sessions.DB_PATH", path), \
-             patch("session_recall.commands.list_sessions.detect_repo", return_value="owner/repo"):
+        with (
+            patch("session_recall.commands.list_sessions.DB_PATH", path),
+            patch(
+                "session_recall.commands.list_sessions.detect_repo",
+                return_value="owner/repo",
+            ),
+        ):
             from session_recall.commands.list_sessions import run
+
             args = SimpleNamespace(repo=None, limit=10, days=30, json=True)
             buf = StringIO()
             with patch("sys.stdout", buf):
@@ -64,9 +89,15 @@ def test_list_respects_limit():
     """List should respect --limit."""
     path = _create_test_db()
     try:
-        with patch("session_recall.commands.list_sessions.DB_PATH", path), \
-             patch("session_recall.commands.list_sessions.detect_repo", return_value="owner/repo"):
+        with (
+            patch("session_recall.commands.list_sessions.DB_PATH", path),
+            patch(
+                "session_recall.commands.list_sessions.detect_repo",
+                return_value="owner/repo",
+            ),
+        ):
             from session_recall.commands.list_sessions import run
+
             args = SimpleNamespace(repo=None, limit=1, days=30, json=True)
             buf = StringIO()
             with patch("sys.stdout", buf):
@@ -81,9 +112,15 @@ def test_list_json_shape():
     """JSON output must have repo, count, sessions keys."""
     path = _create_test_db()
     try:
-        with patch("session_recall.commands.list_sessions.DB_PATH", path), \
-             patch("session_recall.commands.list_sessions.detect_repo", return_value="owner/repo"):
+        with (
+            patch("session_recall.commands.list_sessions.DB_PATH", path),
+            patch(
+                "session_recall.commands.list_sessions.detect_repo",
+                return_value="owner/repo",
+            ),
+        ):
             from session_recall.commands.list_sessions import run
+
             args = SimpleNamespace(repo="all", limit=10, days=30, json=True)
             buf = StringIO()
             with patch("sys.stdout", buf):
@@ -96,3 +133,82 @@ def test_list_json_shape():
             assert "turns_count" in output["sessions"][0]
     finally:
         os.unlink(path)
+
+
+def test_list_tops_up_from_all_scope_when_sparse_repo_results():
+    """When repo scope is sparse, list should top up from all-scope sessions."""
+
+    class _FakeProvider:
+        provider_id = "cli"
+
+        def schema_problems(self):
+            return []
+
+        def list_sessions(self, repo=None, limit=10, days=None):
+            scoped = [
+                {
+                    "provider": "cli",
+                    "id_short": "scoped001",
+                    "id_full": "scoped001-0000-0000-0000-000000000000",
+                    "repository": "owner/repo",
+                    "branch": "main",
+                    "summary": "scoped",
+                    "date": "2026-04-22",
+                    "created_at": "2026-04-22T10:00:00Z",
+                    "turns_count": 1,
+                    "files_count": 0,
+                }
+            ]
+            all_rows = scoped + [
+                {
+                    "provider": "cli",
+                    "id_short": "all00002",
+                    "id_full": "all00002-0000-0000-0000-000000000000",
+                    "repository": "local:/home/jshessen/.config/squad",
+                    "branch": "unknown",
+                    "summary": "all-scope",
+                    "date": "2026-04-22",
+                    "created_at": "2026-04-22T11:00:00Z",
+                    "turns_count": 2,
+                    "files_count": 0,
+                }
+            ]
+            return (all_rows if repo == "all" else scoped)[:limit]
+
+        def recent_files(self, repo=None, limit=10, days=None):
+            return []
+
+    class _FakeVscodeProvider:
+        provider_id = "vscode"
+
+        def schema_problems(self):
+            return []
+
+        def list_sessions(self, repo=None, limit=10, days=None):
+            return []
+
+        def recent_files(self, repo=None, limit=10, days=None):
+            return []
+
+    with (
+        patch(
+            "session_recall.commands.list_sessions.get_active_providers",
+            return_value=[_FakeProvider(), _FakeVscodeProvider()],
+        ),
+        patch(
+            "session_recall.commands.list_sessions.detect_repo",
+            return_value="owner/repo",
+        ),
+    ):
+        from session_recall.commands.list_sessions import run
+
+        args = SimpleNamespace(repo=None, limit=5, days=30, json=True, provider="all")
+        buf = StringIO()
+        with patch("sys.stdout", buf):
+            code = run(args)
+
+    payload = json.loads(buf.getvalue())
+    assert code == 0
+    assert payload["repo"] == "all"
+    assert payload["scope_fallback_used"] is True
+    assert payload["count"] >= 2

--- a/src/session_recall/tests/test_list_sessions.py
+++ b/src/session_recall/tests/test_list_sessions.py
@@ -4,7 +4,6 @@ import sqlite3
 import tempfile
 import os
 import json
-import sys
 from unittest.mock import patch
 from io import StringIO
 from types import SimpleNamespace
@@ -101,7 +100,7 @@ def test_list_respects_limit():
             args = SimpleNamespace(repo=None, limit=1, days=30, json=True)
             buf = StringIO()
             with patch("sys.stdout", buf):
-                code = run(args)
+                run(args)
             output = json.loads(buf.getvalue())
             assert output["count"] == 1
     finally:
@@ -124,7 +123,7 @@ def test_list_json_shape():
             args = SimpleNamespace(repo="all", limit=10, days=30, json=True)
             buf = StringIO()
             with patch("sys.stdout", buf):
-                code = run(args)
+                run(args)
             output = json.loads(buf.getvalue())
             assert "repo" in output
             assert "count" in output

--- a/src/session_recall/tests/test_provider_backends.py
+++ b/src/session_recall/tests/test_provider_backends.py
@@ -1,0 +1,254 @@
+"""Tests for provider backends and fallback parsing behavior."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from session_recall.providers.copilot_cli import CopilotCliProvider
+from session_recall.providers.file_backends import (
+    VSCodeProvider,
+    _extract_role,
+    _extract_text,
+)
+
+
+def test_vscode_kind1_inputtext_extraction() -> None:
+    row = {
+        "kind": 1,
+        "k": ["inputState", "inputText"],
+        "v": "Please fix the auth timeout regression",
+    }
+    assert _extract_role(row) == "user"
+    assert _extract_text(row) == "Please fix the auth timeout regression"
+
+
+def test_cli_fallback_reads_session_state(monkeypatch, tmp_path: Path) -> None:
+    state_root = tmp_path / "session-state"
+    session_dir = state_root / "abcd1234-0000-0000-0000-000000000000"
+    session_dir.mkdir(parents=True)
+    events = session_dir / "events.jsonl"
+
+    payloads = [
+        {
+            "type": "session.start",
+            "data": {
+                "sessionId": "abcd1234-0000-0000-0000-000000000000",
+                "context": {"cwd": "/tmp/project"},
+            },
+            "timestamp": "2026-04-22T10:00:00.000Z",
+        },
+        {
+            "type": "user.message",
+            "data": {"content": "Investigate auth timeout"},
+            "timestamp": "2026-04-22T10:01:00.000Z",
+        },
+        {
+            "type": "assistant.message",
+            "data": {"content": "I will inspect recent traces."},
+            "timestamp": "2026-04-22T10:01:10.000Z",
+        },
+    ]
+    events.write_text(
+        "\n".join(json.dumps(p) for p in payloads) + "\n", encoding="utf-8"
+    )
+
+    monkeypatch.setattr(
+        "session_recall.providers.copilot_cli.detect_repo_for_cwd",
+        lambda cwd: "owner/repo",
+    )
+
+    provider = CopilotCliProvider(
+        db_path=str(tmp_path / "missing.db"), state_root=str(state_root)
+    )
+
+    assert provider.is_available() is True
+
+    sessions = provider.list_sessions(repo="owner/repo", limit=5, days=None)
+    assert len(sessions) == 1
+    assert sessions[0]["provider"] == "cli"
+    assert sessions[0]["repository"] == "owner/repo"
+    assert sessions[0]["summary"].startswith("Investigate auth timeout")
+    assert sessions[0]["turns_count"] == 2
+
+    session = provider.get_session("abcd1234", turns=5, full=False)
+    assert session is not None
+    assert session["id"].startswith("abcd1234")
+    assert session["repository"] == "owner/repo"
+    assert len(session["turns"]) == 2
+
+    results = provider.search("timeout", repo="owner/repo", limit=5, days=None)
+    assert len(results) >= 1
+    assert results[0]["provider"] == "cli"
+
+
+def test_cli_fallback_prefers_context_repository_field(tmp_path: Path) -> None:
+    state_root = tmp_path / "session-state"
+    session_dir = state_root / "efgh5678-0000-0000-0000-000000000000"
+    session_dir.mkdir(parents=True)
+    events = session_dir / "events.jsonl"
+
+    payloads = [
+        {
+            "type": "session.start",
+            "data": {
+                "sessionId": "efgh5678-0000-0000-0000-000000000000",
+                "context": {
+                    "cwd": "/not/a/repo",
+                    "repository": "dezgit2025/auto-memory",
+                },
+            },
+            "timestamp": "2026-04-22T18:00:00.000Z",
+        },
+        {
+            "type": "user.message",
+            "data": {"content": "can you fix the broken skills?"},
+            "timestamp": "2026-04-22T18:01:00.000Z",
+        },
+    ]
+    events.write_text(
+        "\n".join(json.dumps(p) for p in payloads) + "\n", encoding="utf-8"
+    )
+
+    provider = CopilotCliProvider(
+        db_path=str(tmp_path / "missing.db"), state_root=str(state_root)
+    )
+    sessions = provider.list_sessions(repo="dezgit2025/auto-memory", limit=5, days=None)
+
+    assert len(sessions) == 1
+    assert sessions[0]["repository"] == "dezgit2025/auto-memory"
+
+    results = provider.search(
+        "broken skills", repo="dezgit2025/auto-memory", limit=5, days=None
+    )
+    assert len(results) == 1
+    assert results[0]["repository"] == "dezgit2025/auto-memory"
+
+
+def test_cli_fallback_uses_tool_path_to_infer_repository(
+    monkeypatch, tmp_path: Path
+) -> None:
+    state_root = tmp_path / "session-state"
+    session_dir = state_root / "toolpath-0000-0000-0000-000000000000"
+    session_dir.mkdir(parents=True)
+    events = session_dir / "events.jsonl"
+
+    payloads = [
+        {
+            "type": "session.start",
+            "data": {
+                "sessionId": "toolpath-0000-0000-0000-000000000000",
+                "context": {"cwd": "/tmp"},
+            },
+            "timestamp": "2026-04-22T18:10:00.000Z",
+        },
+        {
+            "type": "tool.execution_start",
+            "data": {"arguments": {"path": "/work/auto-memory/src"}},
+            "timestamp": "2026-04-22T18:10:05.000Z",
+        },
+        {
+            "type": "user.message",
+            "data": {"content": "trace skills fixes"},
+            "timestamp": "2026-04-22T18:10:10.000Z",
+        },
+    ]
+    events.write_text(
+        "\n".join(json.dumps(p) for p in payloads) + "\n", encoding="utf-8"
+    )
+
+    monkeypatch.setattr(
+        "session_recall.providers.copilot_cli.detect_repo_for_cwd",
+        lambda cwd: (
+            "dezgit2025/auto-memory"
+            if cwd == "/work/auto-memory/src" or cwd == "/work/auto-memory"
+            else None
+        ),
+    )
+
+    provider = CopilotCliProvider(
+        db_path=str(tmp_path / "missing.db"), state_root=str(state_root)
+    )
+    sessions = provider.list_sessions(repo="dezgit2025/auto-memory", limit=5, days=None)
+
+    assert len(sessions) == 1
+    assert sessions[0]["repository"] == "dezgit2025/auto-memory"
+
+
+def test_cli_fallback_labels_non_repo_session_as_local_workspace(
+    tmp_path: Path,
+) -> None:
+    state_root = tmp_path / "session-state"
+    session_dir = state_root / "local-0000-0000-0000-000000000000"
+    session_dir.mkdir(parents=True)
+    events = session_dir / "events.jsonl"
+
+    payloads = [
+        {
+            "type": "session.start",
+            "data": {
+                "sessionId": "local-0000-0000-0000-000000000000",
+                "context": {"cwd": "/home/jshessen/.config/squad"},
+            },
+            "timestamp": "2026-04-22T18:20:00.000Z",
+        },
+        {
+            "type": "user.message",
+            "data": {"content": "can you fix the broken skills?"},
+            "timestamp": "2026-04-22T18:20:05.000Z",
+        },
+    ]
+    events.write_text(
+        "\n".join(json.dumps(p) for p in payloads) + "\n", encoding="utf-8"
+    )
+
+    provider = CopilotCliProvider(
+        db_path=str(tmp_path / "missing.db"), state_root=str(state_root)
+    )
+    sessions = provider.list_sessions(repo="all", limit=5, days=None)
+
+    assert len(sessions) == 1
+    assert sessions[0]["repository"] == "local:/home/jshessen/.config/squad"
+
+
+def test_vscode_provider_includes_results_when_repo_filter_is_set(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "workspaceStorage"
+    chat_dir = root / "abc" / "chatSessions"
+    chat_dir.mkdir(parents=True)
+    fp = chat_dir / "session.jsonl"
+
+    rows = [
+        {
+            "kind": 1,
+            "k": ["inputState", "inputText"],
+            "v": "Continue API refactor plan",
+        },
+        {"kind": 2, "v": [{"message": "I'll pick up where we left off."}]},
+    ]
+    fp.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+
+    provider = VSCodeProvider(root_override=str(root))
+    sessions = provider.list_sessions(repo="owner/repo", limit=5, days=None)
+
+    assert len(sessions) == 1
+    assert sessions[0]["provider"] == "vscode"
+    assert sessions[0]["summary"].startswith("Continue API refactor")
+
+
+def test_vscode_provider_skips_pathological_jsonl_lines(tmp_path: Path) -> None:
+    root = tmp_path / "workspaceStorage"
+    chat_dir = root / "xyz" / "chatSessions"
+    chat_dir.mkdir(parents=True)
+    fp = chat_dir / "session.jsonl"
+
+    huge_line = "{" + ('"x":' + '"' + ("a" * 600_000) + '"') + "}"
+    valid_row = {"kind": 1, "k": ["inputState", "inputText"], "v": "normal prompt text"}
+    fp.write_text(huge_line + "\n" + json.dumps(valid_row) + "\n", encoding="utf-8")
+
+    provider = VSCodeProvider(root_override=str(root))
+    sessions = provider.list_sessions(repo="all", limit=5, days=None)
+
+    assert len(sessions) == 1
+    assert sessions[0]["turns_count"] == 1

--- a/src/session_recall/tests/test_repo_scope_fallback.py
+++ b/src/session_recall/tests/test_repo_scope_fallback.py
@@ -1,0 +1,133 @@
+"""Tests for repo-scope fallback in list/search commands."""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+class _FakeProvider:
+    provider_id = "cli"
+
+    def __init__(
+        self,
+        scoped_sessions=None,
+        all_sessions=None,
+        scoped_results=None,
+        all_results=None,
+    ):
+        self._scoped_sessions = scoped_sessions or []
+        self._all_sessions = all_sessions or []
+        self._scoped_results = scoped_results or []
+        self._all_results = all_results or []
+
+    def schema_problems(self):
+        return []
+
+    def list_sessions(self, repo, limit, days):
+        rows = self._all_sessions if repo == "all" else self._scoped_sessions
+        return rows[:limit]
+
+    def recent_files(self, repo, limit, days):
+        return []
+
+    def search(self, query, repo, limit, days):
+        rows = self._all_results if repo == "all" else self._scoped_results
+        return rows[:limit]
+
+
+def test_list_falls_back_to_all_scope_when_scoped_is_empty():
+    cli_provider = _FakeProvider(
+        scoped_sessions=[],
+        all_sessions=[
+            {
+                "provider": "fake",
+                "id_short": "abc12345",
+                "id_full": "abc12345-0000-0000-0000-000000000000",
+                "repository": "unknown",
+                "branch": "unknown",
+                "summary": "skills fix session",
+                "date": "2026-04-22",
+                "created_at": "2026-04-22T17:00:00Z",
+                "turns_count": 3,
+                "files_count": 0,
+            }
+        ],
+    )
+
+    class _OtherProvider:
+        provider_id = "vscode"
+
+        def schema_problems(self):
+            return []
+
+        def list_sessions(self, repo, limit, days):
+            return []
+
+        def recent_files(self, repo, limit, days):
+            return []
+
+    providers = [cli_provider, _OtherProvider()]
+
+    args = SimpleNamespace(repo=None, limit=10, days=5, json=True, provider="all")
+    with (
+        patch(
+            "session_recall.commands.list_sessions.detect_repo",
+            return_value="owner/repo",
+        ),
+        patch(
+            "session_recall.commands.list_sessions.get_active_providers",
+            return_value=providers,
+        ),
+    ):
+        from session_recall.commands.list_sessions import run
+
+        buf = StringIO()
+        with patch("sys.stdout", buf):
+            code = run(args)
+
+    payload = json.loads(buf.getvalue())
+    assert code == 0
+    assert payload["repo"] == "all"
+    assert payload["count"] == 1
+
+
+def test_search_falls_back_to_all_scope_when_scoped_is_empty():
+    provider = _FakeProvider(
+        scoped_results=[],
+        all_results=[
+            {
+                "provider": "fake",
+                "session_id": "abc12345",
+                "session_id_full": "abc12345-0000-0000-0000-000000000000",
+                "source_type": "turn",
+                "summary": "can you fix the broken skills?",
+                "repository": "unknown",
+                "date": "2026-04-22",
+                "content": "can you fix the broken skills?",
+            }
+        ],
+    )
+
+    args = SimpleNamespace(
+        query="broken skills", repo=None, limit=10, days=5, json=True, provider="all"
+    )
+    with (
+        patch("session_recall.commands.search.detect_repo", return_value="owner/repo"),
+        patch(
+            "session_recall.commands.search.get_active_providers",
+            return_value=[provider],
+        ),
+    ):
+        from session_recall.commands.search import run
+
+        buf = StringIO()
+        with patch("sys.stdout", buf):
+            code = run(args)
+
+    payload = json.loads(buf.getvalue())
+    assert code == 0
+    assert payload["repo"] == "all"
+    assert payload["count"] == 1

--- a/src/session_recall/tests/test_repos_command.py
+++ b/src/session_recall/tests/test_repos_command.py
@@ -1,0 +1,104 @@
+"""Tests for repos discovery summary command."""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+class _FakeProvider:
+    def __init__(self, provider_id: str, rows: list[dict]) -> None:
+        self.provider_id = provider_id
+        self._rows = rows
+
+    def list_sessions(self, repo, limit, days):
+        assert repo == "all"
+        return self._rows[:limit]
+
+
+def test_repos_json_aggregates_by_repository() -> None:
+    providers = [
+        _FakeProvider(
+            "cli",
+            [
+                {
+                    "provider": "cli",
+                    "repository": "jshessen/auto-memory",
+                    "created_at": "2026-04-22T12:00:00Z",
+                },
+                {
+                    "provider": "cli",
+                    "repository": "local:/home/jshessen/.config/squad",
+                    "created_at": "2026-04-22T13:00:00Z",
+                },
+            ],
+        ),
+        _FakeProvider(
+            "vscode",
+            [
+                {
+                    "provider": "vscode",
+                    "repository": "jshessen/auto-memory",
+                    "created_at": "2026-04-22T14:00:00Z",
+                }
+            ],
+        ),
+    ]
+
+    with patch(
+        "session_recall.commands.repos.get_active_providers", return_value=providers
+    ):
+        from session_recall.commands.repos import run
+
+        args = SimpleNamespace(
+            json=True, limit=100, days=30, provider="all", include_local=False
+        )
+        buf = StringIO()
+        with patch("sys.stdout", buf):
+            code = run(args)
+
+    payload = json.loads(buf.getvalue())
+    assert code == 0
+    assert payload["count"] == 1
+    assert payload["include_local"] is False
+    repos = {row["repository"]: row for row in payload["repositories"]}
+    assert repos["jshessen/auto-memory"]["session_count"] == 2
+    assert repos["jshessen/auto-memory"]["last_seen"] == "2026-04-22T14:00:00Z"
+    assert repos["jshessen/auto-memory"]["providers"] == ["cli", "vscode"]
+
+
+def test_repos_json_include_local_opt_in() -> None:
+    providers = [
+        _FakeProvider(
+            "cli",
+            [
+                {
+                    "provider": "cli",
+                    "repository": "local:/home/jshessen/.config/squad",
+                    "created_at": "2026-04-22T13:00:00Z",
+                }
+            ],
+        )
+    ]
+
+    with patch(
+        "session_recall.commands.repos.get_active_providers", return_value=providers
+    ):
+        from session_recall.commands.repos import run
+
+        args = SimpleNamespace(
+            json=True, limit=100, days=30, provider="all", include_local=True
+        )
+        buf = StringIO()
+        with patch("sys.stdout", buf):
+            code = run(args)
+
+    payload = json.loads(buf.getvalue())
+    assert code == 0
+    assert payload["count"] == 1
+    assert payload["include_local"] is True
+    assert (
+        payload["repositories"][0]["repository"] == "local:/home/jshessen/.config/squad"
+    )

--- a/src/session_recall/tests/test_search_sanitize.py
+++ b/src/session_recall/tests/test_search_sanitize.py
@@ -1,5 +1,4 @@
 """Tests for FTS5 query sanitization in search command."""
-import pytest
 from session_recall.commands.search import sanitize_fts5_query
 
 

--- a/src/session_recall/tests/test_telemetry.py
+++ b/src/session_recall/tests/test_telemetry.py
@@ -1,6 +1,5 @@
 """Tests for util/telemetry.py — new tier/query_hash/window fields + backward compat."""
 import json
-from pathlib import Path
 import pytest
 from session_recall.util import telemetry
 

--- a/src/session_recall/types.py
+++ b/src/session_recall/types.py
@@ -1,21 +1,46 @@
 from __future__ import annotations
 from typing import TypedDict
 
+
 class SessionRecord(TypedDict):
-    id: str; repository: str; branch: str; summary: str
-    created_at: str; updated_at: str; turns_count: int; files_count: int
+    id: str
+    repository: str
+    branch: str
+    summary: str
+    created_at: str
+    updated_at: str
+    turns_count: int
+    files_count: int
+
 
 class TurnRecord(TypedDict):
-    turn_index: int; user_message: str; assistant_response: str; timestamp: str
+    turn_index: int
+    user_message: str
+    assistant_response: str
+    timestamp: str
+
 
 class FileRecord(TypedDict):
-    file_path: str; tool_name: str; turn_index: int
+    file_path: str
+    tool_name: str
+    turn_index: int
+
 
 class CheckpointRecord(TypedDict):
-    checkpoint_number: int; title: str; overview: str; created_at: str
+    checkpoint_number: int
+    title: str
+    overview: str
+    created_at: str
+
 
 class HealthDimResult(TypedDict):
-    name: str; score: float; detail: str
+    name: str
+    score: float
+    detail: str
+
 
 class TelemetryEntry(TypedDict):
-    command: str; timestamp: str; duration_ms: int; ok: bool
+    command: str
+    timestamp: str
+    duration_ms: int
+    ok: bool

--- a/src/session_recall/util/detect_repo.py
+++ b/src/session_recall/util/detect_repo.py
@@ -1,6 +1,34 @@
 """Detect current repository from git remote or environment."""
+
 import subprocess
 import re
+
+
+def parse_repo_url(url: str) -> str | None:
+    """Parse owner/repo from common git remote URL formats."""
+    if not url:
+        return None
+    m = re.match(r"git@[^:]+:(.+?)(?:\.git)?$", url)
+    if m:
+        return m.group(1)
+    m = re.match(r"https?://[^/]+/(.+?)(?:\.git)?$", url)
+    if m:
+        return m.group(1)
+    return None
+
+
+def detect_repo_for_cwd(cwd: str, timeout: int = 5) -> str | None:
+    """Return owner/repo for a specific working directory path."""
+    try:
+        url = subprocess.run(
+            ["git", "-C", cwd, "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        ).stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+    return parse_repo_url(url)
 
 
 def detect_repo() -> str | None:
@@ -8,18 +36,10 @@ def detect_repo() -> str | None:
     try:
         url = subprocess.run(
             ["git", "remote", "get-url", "origin"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True,
+            text=True,
+            timeout=5,
         ).stdout.strip()
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return None
-    if not url:
-        return None
-    # Handle SSH: git@github.com:owner/repo.git
-    m = re.match(r"git@[^:]+:(.+?)(?:\.git)?$", url)
-    if m:
-        return m.group(1)
-    # Handle HTTPS: https://github.com/owner/repo.git
-    m = re.match(r"https?://[^/]+/(.+?)(?:\.git)?$", url)
-    if m:
-        return m.group(1)
-    return None
+    return parse_repo_url(url)

--- a/src/session_recall/util/format_output.py
+++ b/src/session_recall/util/format_output.py
@@ -1,21 +1,22 @@
 """Output formatting for human-readable and JSON modes."""
+
 import json
 import re
 
 _CONTROL_RE = re.compile(
-    r'\x1b\[[0-?]*[ -/]*[@-~]'             # CSI sequences (colors, cursor moves)
-    r'|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)'  # OSC sequences (title, clipboard, hyperlinks)
-    r'|\x1b[@-Z\\-_]'                       # other ESC-prefixed (Fp, Fe, Fs)
-    r'|[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'  # C0 controls (except TAB \x09, LF \x0a, CR \x0d) + DEL
-    r'|[\x80-\x9f]'                         # C1 controls
+    r"\x1b\[[0-?]*[ -/]*[@-~]"  # CSI sequences (colors, cursor moves)
+    r"|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)"  # OSC sequences (title, clipboard, hyperlinks)
+    r"|\x1b[@-Z\\-_]"  # other ESC-prefixed (Fp, Fe, Fs)
+    r"|[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]"  # C0 controls (except TAB \x09, LF \x0a, CR \x0d) + DEL
+    r"|[\x80-\x9f]"  # C1 controls
 )
 
 
 def sanitize_for_terminal(s: str | None) -> str:
     """Strip ANSI/OSC/control sequences so session content can't hijack the terminal."""
     if not s:
-        return ''
-    return _CONTROL_RE.sub('', s)
+        return ""
+    return _CONTROL_RE.sub("", s)
 
 
 def fmt_json(data: dict | list) -> str:
@@ -28,14 +29,17 @@ def fmt_human_sessions(sessions: list[dict]) -> str:
     if not sessions:
         return "No sessions found."
     lines = []
-    lines.append(f"{'ID':8s}  {'Date':10s}  {'Turns':>5s}  {'Summary'}")
-    lines.append("-" * 60)
+    lines.append(
+        f"{'ID':8s}  {'Date':10s}  {'Repository/Workspace':28s}  {'Turns':>5s}  {'Summary'}"
+    )
+    lines.append("-" * 100)
     for s in sessions:
         sid = sanitize_for_terminal(s.get("id_short", s.get("id", "?")[:8]))
         date = sanitize_for_terminal(s.get("date", s.get("created_at", "?"))[:10])
+        repo = sanitize_for_terminal((s.get("repository") or "unknown")[:28])
         turns = str(s.get("turns_count", s.get("turns", "?")))
         summary = sanitize_for_terminal((s.get("summary") or "(untitled)")[:40])
-        lines.append(f"{sid:8s}  {date:10s}  {turns:>5s}  {summary}")
+        lines.append(f"{sid:8s}  {date:10s}  {repo:28s}  {turns:>5s}  {summary}")
     return "\n".join(lines)
 
 

--- a/src/session_recall/util/telemetry.py
+++ b/src/session_recall/util/telemetry.py
@@ -1,6 +1,7 @@
 """Telemetry ring buffer for session-recall invocations."""
 import hashlib
-import json, time
+import json
+import time
 from pathlib import Path
 
 _TELEMETRY_PATH = None
@@ -40,10 +41,14 @@ def record(cmd: str, duration_ms: int, busy_hits: int = 0,
             "exit_code": exit_code, "schema_ok": schema_ok,
         }
         # Only include non-None optional fields — keeps legacy schema clean
-        if tier is not None: entry["tier"] = tier
-        if query_hash is not None: entry["query_hash"] = query_hash
-        if session_id_prefix is not None: entry["session_id_prefix"] = session_id_prefix
-        if window_tier is not None: entry["window_tier"] = window_tier
+        if tier is not None:
+            entry["tier"] = tier
+        if query_hash is not None:
+            entry["query_hash"] = query_hash
+        if session_id_prefix is not None:
+            entry["session_id_prefix"] = session_id_prefix
+        if window_tier is not None:
+            entry["window_tier"] = window_tier
         entries.append(entry)
         entries = entries[-500:]  # Ring buffer: 100 → 500
         path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
This PR resolves Copilot CLI 1.0.34+ storage compatibility by introducing **provider-based multi-storage recall** instead of assuming a single SQLite layout.

Closes #3

## Storage model coverage by provider

| Provider | Storage location(s) | Storage format | Commands supported |
|---|---|---|---|
| `cli` (Copilot CLI) | `~/.copilot/session-store.db` | SQLite (legacy/current where present) | `list`, `search`, `show`, `files`, `checkpoints`, `health`, `schema-check` |
| `cli` fallback | `~/.copilot/session-state/*/events.jsonl` | JSONL events | `list`, `search`, `show` (schema-check reports compatibility mode) |
| `vscode` | `~/.config/Code/User/workspaceStorage/**/chatSessions/*.jsonl` (+ flatpak/snap variants) | JSONL logs | `list`, `search`, `show`, `files` |
| `jetbrains` | `~/.config/github-copilot/chat-sessions/*` + related chat files | file-backed JSON/session logs | `list`, `search`, `show`, `files` |
| `neovim` | `~/.config/github-copilot/**` and `~/.local/share/nvim/**` chat JSON/JSONL | file-backed JSON/JSONL | `list`, `search`, `show`, `files` |

### Environment overrides supported
- `SESSION_RECALL_DB`
- `SESSION_RECALL_CLI_STATE_ROOT`
- `SESSION_RECALL_VSCODE_STORAGE`
- `SESSION_RECALL_JETBRAINS_ROOT`
- `SESSION_RECALL_NEOVIM_ROOT`

## Runtime behavior and fallback semantics

### Provider discovery
At runtime, providers are discovered and filtered to those actually available on the machine:
- CLI provider is available if either SQLite DB exists **or** session-state event files exist.
- File-backed providers are available when their roots exist.

### Command behavior in multi-storage mode
- `list`, `search`, `show`, `files`, `checkpoints` now route through active providers.
- `schema-check` is provider-aware:
  - Performs strict schema checks when CLI SQLite is present.
  - Returns compatibility detail (`session-state-or-sqlite`) when fallback event storage is active.
- `health` is provider-aware:
  - Runs SQLite health dimensions when SQLite is available.
  - Falls back to provider compatibility dimensions when SQLite is not available.

## UX and recall quality improvements
- Added `session-recall repos` to summarize discovered repositories/workspaces across providers.
- Improved repository attribution for CLI session-state parsing.
- Improved list/repos alignment and sparse-scope behavior so recall output better matches discovered session reality.

## What changed
- Added provider architecture:
  - `src/session_recall/providers/` (`base.py`, `discovery.py`, `copilot_cli.py`, `file_backends.py`, `common.py`)
- Added repo discovery command:
  - `src/session_recall/commands/repos.py`
- Updated command paths for provider fallback and multi-storage context:
  - `list`, `search`, `show`, `files`, `checkpoints`, `health`, `schema-check`
- Improved repo detection/output formatting:
  - `src/session_recall/util/detect_repo.py`
  - `src/session_recall/util/format_output.py`
- Added/updated tests:
  - `test_provider_backends.py`
  - `test_health_schema_multistorage.py`
  - `test_repo_scope_fallback.py`
  - `test_repos_command.py`
  - updates in `test_list_sessions.py`

## How this differs from PR #4
PR #4 primarily introduces a DB-layer adapter approach (`db/jsonl_store.py` + connect/schema integration).

This PR addresses the same issue via **provider routing and command-layer fallback**, including:
- dynamic provider discovery,
- explicit session-state support for CLI,
- cross-surface file-backed providers (VS Code / JetBrains / Neovim),
- and provider-aware health/schema semantics.

Both aim at Issue #3 but with different architecture and operational surface area.

## Validation
- `pytest src/session_recall/tests/ -q` → 105 passed
- `ruff check src/` → all checks passed
- Focused suite:
  - `pytest -q src/session_recall/tests/test_provider_backends.py src/session_recall/tests/test_repo_scope_fallback.py src/session_recall/tests/test_repos_command.py src/session_recall/tests/test_list_sessions.py src/session_recall/tests/test_health_schema_multistorage.py` → 18 passed

## CONTRIBUTING checklist
- [x] Tests pass: `pytest src/session_recall/tests/ -q`
- [x] Lint passes: `ruff check src/`
- [x] No new runtime dependencies added
- [x] Docs updated for behavior changes (`README.md`)
