### PR TITLE
fix(dim_freshness): check WAL mtime to avoid false-stale freshness reports

### DIFF
--- a/src/session_recall/health/dim_freshness.py
+++ b/src/session_recall/health/dim_freshness.py
@@ -9,7 +9,11 @@ HINT = "Use Copilot CLI — DB only updates from active sessions"
 
 def check() -> dict:
     try:
-        mtime = os.path.getmtime(DB_PATH)
+        wal_path = DB_PATH + "-wal"
+        mtime = max(
+            os.path.getmtime(DB_PATH),
+            os.path.getmtime(wal_path) if os.path.exists(wal_path) else 0,
+        )
         age_hours = (time.time() - mtime) / 3600
     except OSError:
         return {"name": "DB Freshness", "score": 0, "zone": "RED",

--- a/src/session_recall/tests/test_dim_freshness.py
+++ b/src/session_recall/tests/test_dim_freshness.py
@@ -1,0 +1,65 @@
+"""Tests for health/dim_freshness.py — WAL-aware mtime freshness check."""
+import time
+from session_recall.health import dim_freshness
+
+
+def test_green_when_db_recently_modified(tmp_path, monkeypatch):
+    db = tmp_path / "session-store.db"
+    db.write_text("")
+    monkeypatch.setattr(dim_freshness, "DB_PATH", str(db))
+    r = dim_freshness.check()
+    assert r["zone"] == "GREEN"
+
+
+def test_red_when_db_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(dim_freshness, "DB_PATH", str(tmp_path / "missing.db"))
+    r = dim_freshness.check()
+    assert r["zone"] == "RED"
+    assert "not found" in r["detail"]
+
+
+def test_wal_mtime_used_when_newer_than_db(tmp_path, monkeypatch):
+    """WAL file is newer than the main DB — freshness should reflect the WAL."""
+    db = tmp_path / "session-store.db"
+    wal = tmp_path / "session-store.db-wal"
+    db.write_text("")
+    wal.write_text("")
+
+    # Make the main DB appear stale (100 hours ago)
+    stale_time = time.time() - (100 * 3600)
+    import os
+    os.utime(str(db), (stale_time, stale_time))
+
+    # WAL is fresh (just now — default mtime from write_text is fine)
+    monkeypatch.setattr(dim_freshness, "DB_PATH", str(db))
+
+    r = dim_freshness.check()
+    assert r["zone"] == "GREEN", (
+        f"Expected GREEN (WAL is fresh) but got {r['zone']}: {r['detail']}"
+    )
+
+
+def test_db_mtime_used_when_no_wal(tmp_path, monkeypatch):
+    """No WAL file present — falls back to main DB mtime only."""
+    db = tmp_path / "session-store.db"
+    db.write_text("")
+    monkeypatch.setattr(dim_freshness, "DB_PATH", str(db))
+    r = dim_freshness.check()
+    assert r["zone"] == "GREEN"
+
+
+def test_stale_when_both_db_and_wal_are_old(tmp_path, monkeypatch):
+    """Both DB and WAL are old — should report RED."""
+    import os
+    db = tmp_path / "session-store.db"
+    wal = tmp_path / "session-store.db-wal"
+    db.write_text("")
+    wal.write_text("")
+
+    stale_time = time.time() - (100 * 3600)
+    os.utime(str(db), (stale_time, stale_time))
+    os.utime(str(wal), (stale_time, stale_time))
+
+    monkeypatch.setattr(dim_freshness, "DB_PATH", str(db))
+    r = dim_freshness.check()
+    assert r["zone"] == "RED"


### PR DESCRIPTION
## Problem

SQLite in WAL mode writes new data to `session-store.db-wal` first. The main `.db` file is only updated when a checkpoint occurs (periodically, not on every write).

The `dim_freshness` check was using `os.path.getmtime(DB_PATH)` — the main file only. This meant that even with active sessions being recorded, the freshness dimension would report AMBER or RED because the main file's mtime hadn't changed.

## Fix

Take the most recent mtime across both the main DB and the WAL file:

```python
wal_path = DB_PATH + "-wal"
mtime = max(
    os.path.getmtime(DB_PATH),
    os.path.getmtime(wal_path) if os.path.exists(wal_path) else 0,
)
```

This correctly reflects when data was last written, regardless of checkpoint timing.

## Tests added

New file: `src/session_recall/tests/test_dim_freshness.py` (5 tests)

| Test | Scenario |
|------|----------|
| `test_green_when_db_recently_modified` | Recent DB → GREEN |
| `test_red_when_db_missing` | No DB file → RED |
| `test_wal_mtime_used_when_newer_than_db` | WAL is fresh, DB is 100h stale → GREEN (key regression test) |
| `test_db_mtime_used_when_no_wal` | No WAL present → falls back to DB mtime |
| `test_stale_when_both_db_and_wal_are_old` | Both DB and WAL are old → RED |

## Verified locally

- Freshness now reports `0.0h old` (GREEN) after active sessions, vs previously showing 68h old (AMBER)
- All 95 tests pass (90 existing + 5 new)